### PR TITLE
Removed call to gw.setPALevel(RF24_PA_LOW) because the gateway PA Level ...

### DIFF
--- a/SerialGateway/SerialGateway.ino
+++ b/SerialGateway/SerialGateway.ino
@@ -48,7 +48,6 @@ boolean commandComplete = false;  // whether the string is complete
 void setup()  
 { 
   gw.begin();
-  gw.setPALevel(RF24_PA_LOW);  //Adjust PA-level: MIN, LOW, HIGH, MAX (MAX can sometimes cause problems when using amplified NRF24L01)
 
   // C++ classes and interrupts really sucks. Need to attach interrupt 
   // outside thw Gateway class due to language shortcomings! Gah! 


### PR DESCRIPTION
...is set by RF24_PA_LEVEL_GW in Config.h that is used by the gw.begin() method to set the PA_Level for the gateway.  Users should change the PA_Level for the gateway using RF24_PA_LEVEL_GW in Config.h
