### PR TITLE
fix a possible parent repeater loop

### DIFF
--- a/libraries/MySensors/MyGateway.cpp
+++ b/libraries/MySensors/MyGateway.cpp
@@ -47,6 +47,7 @@ void MyGateway::begin(rf24_pa_dbm_e paLevel, uint8_t channel, rf24_datarate_e da
 	}
 
 	nc.nodeId = 0;
+	nc.parentNodeId = 0;
 	nc.distance = 0;
 	inclusionMode = 0;
 	buttonTriggeredInclusion = false;

--- a/libraries/MySensors/MySensor.cpp
+++ b/libraries/MySensors/MySensor.cpp
@@ -287,7 +287,7 @@ boolean MySensor::process() {
 	if (repeaterMode && command == C_INTERNAL && type == I_FIND_PARENT) {
 		if (nc.distance == 255) {
 			findParentNode();
-		} else {
+		} else if (sender != nc.parentNodeId) {
 			// Relaying nodes should always answer ping messages
 			// Wait a random delay of 0-2 seconds to minimize collision
 			// between ping ack messages from other relaying nodes


### PR DESCRIPTION
If a repeater responds to his parent node, this can cause a loop between the two.

(I managed to sign for both CLAs now)