### PR TITLE
check valid parentNodeId before requestNodeId

### DIFF
--- a/libraries/MySensors/MySensor.cpp
+++ b/libraries/MySensors/MySensor.cpp
@@ -87,22 +87,19 @@ void MySensor::begin(void (*_msgCallback)(const MyMessage &), uint8_t _nodeId, b
 		findParentNode();
 	}
 
-	if ( (_nodeId != AUTO) && (nc.nodeId != _nodeId) ) {
-	    // Set static id
-	    nc.nodeId = _nodeId;
-	    // Save static id in eeprom
-	    eeprom_update_byte((uint8_t*)EEPROM_NODE_ID_ADDRESS, _nodeId);
-	}
-
-	// Try to fetch node-id from gateway
-	if (nc.nodeId == AUTO) {
+	if (_nodeId != AUTO) {
+		// Set static id
+		nc.nodeId = _nodeId;
+		// Save static id in eeprom
+		eeprom_update_byte((uint8_t*)EEPROM_NODE_ID_ADDRESS, _nodeId);
+	} else if (isValidParent(nc.parentNodeId)) {
+		// Try to fetch node-id from gateway
 		requestNodeId();
 	}
 
 	setupNode();
 
 	debug(PSTR("%s started, id=%d, parent=%d, distance=%d\n"), isGateway?"gateway":(repeaterMode?"repeater":"sensor"), nc.nodeId, nc.parentNodeId, nc.distance);
-
 }
 
 void MySensor::setupRepeaterMode(){


### PR DESCRIPTION
To prevent from sending a node id request before receiving a parent node id.
The original idea was to change the line 98:
if (nc.nodeId == AUTO) {
to:
if ( (nc.nodeId == AUTO) && (isValidParent(nc.parentNodeId)) ) {

To save a few bits I thought of joining the two ifs and remove (nc.nodeId != _nodeId) because we are now using "eeprom_update_byte".
Or we still need it for the OTA bootloader ?
https://github.com/mysensors/Arduino/commit/2d214a1e58ba3208a6f901791e351451c5b6a949
