### PR TITLE
Bugfix for gateway signing requirements

### DIFF
--- a/libraries/MySensors/MySensor.cpp
+++ b/libraries/MySensors/MySensor.cpp
@@ -402,8 +402,8 @@ boolean MySensor::process() {
 				// We do not currently want a gateway to require signing from all nodes in a network just because it wants one node
 				// to sign it's messages
 				if (isGateway) {
-					if (requireSigning)
-						sendRoute(build(msg, nc.nodeId, msg.sender, NODE_SENSOR_ID, C_INTERNAL, I_REQUEST_SIGNING, false).set(requireSigning));
+					if (requireSigning && DO_SIGN(msg.sender))
+						sendRoute(build(msg, nc.nodeId, msg.sender, NODE_SENSOR_ID, C_INTERNAL, I_REQUEST_SIGNING, false).set(true));
 					else
 						sendRoute(build(msg, nc.nodeId, msg.sender, NODE_SENSOR_ID, C_INTERNAL, I_REQUEST_SIGNING, false).set(false));
 				}


### PR DESCRIPTION
Gateway now only indicate signing requirements for sensors that in turn have indicated signing requirements.