### PR TITLE
Fixed bug that caused the wrong message to be signed

### DIFF
--- a/libraries/MySensors/MySensor.h
+++ b/libraries/MySensors/MySensor.h
@@ -246,7 +246,8 @@ class MySensor
 	uint16_t doSign[16]; // Bitfield indicating which sensors require signed communication
 
 	MyMessage msg;  // Buffer for incoming messages.
-	MyMessage ack;  // Buffer for ack messages.
+	MyMessage tmpMsg ;  // Buffer for temporary messages (acks and nonces among others).
+	MyMessage msgSign;  // Buffer for message to sign.
 
 	MyRFDriverClass radio;
 


### PR DESCRIPTION
process() altered the message buffer pending signing when
called in sign() causing the wrong message to be sent to the
signing backend. This is resolved by copying the original
message before processing incoming messages to make sure
the original message is kept. After it is successfully signed,
it is copied back to its original location again.