### PR TITLE
Add LEDs blinking into base MySensor class without any library dependency

### DIFF
--- a/libraries/MySensors/MyConfig.h
+++ b/libraries/MySensors/MyConfig.h
@@ -46,6 +46,26 @@
 
 
 /**********************************
+*  Information LEDs blinking
+***********************************/
+// This feature enables LEDs blinking on message receive, transmit
+// or if some error occured. This was commonly used only in gateways,
+// but now can be used in any sensor node. Also the LEDs can now be
+// disabled in the gateway.
+
+// #define WITH_LEDS_BLINKING
+
+// default LEDs blinking period in milliseconds
+#define DEFAULT_LED_BLINK_PERIOD 300
+// The RX LED default pin
+#define DEFAULT_RX_LED_PIN 8
+// The TX LED default pin
+#define DEFAULT_TX_LED_PIN 9
+// The Error LED default pin
+#define DEFAULT_ERR_LED_PIN 7
+
+
+/**********************************
 *  Message Signing Settings
 ***********************************/
 // Disable to completly disable signing functionality in library

--- a/libraries/MySensors/MySensor.cpp
+++ b/libraries/MySensors/MySensor.cpp
@@ -53,11 +53,17 @@ MySensor::MySensor(MyTransport &_radio, MyHw &_hw
 #ifdef MY_SIGNING_FEATURE
 	, MySigning &_signer
 #endif
+#ifdef WITH_LEDS_BLINKING
+		, uint8_t _rx, uint8_t _tx, uint8_t _er, unsigned long _blink_period
+#endif
 	)
 	:
 	radio(_radio),
 #ifdef MY_SIGNING_FEATURE
 	signer(_signer),
+#endif
+#ifdef WITH_LEDS_BLINKING
+	pinRx(_rx), pinTx(_tx), pinEr(_er), ledBlinkPeriod(_blink_period),
 #endif
 #ifdef MY_OTA_FIRMWARE_FEATURE
  	flash(MY_OTA_FLASH_SS, MY_OTA_FLASH_JDECID),
@@ -90,6 +96,64 @@ bool MySensor::isValidFirmware() {
 
 #endif
 
+#ifdef WITH_LEDS_BLINKING
+void MySensor::handleLedsBlinking() {
+	static unsigned long next_time = hw_millis() + ledBlinkPeriod;
+
+	// Just return if it is not the time...
+	// http://playground.arduino.cc/Code/TimingRollover
+	if ((long)(hw_millis() - next_time) < 0)
+		return;
+	else
+		next_time = hw_millis() + ledBlinkPeriod;
+
+	// do the actual blinking
+	if(countRx && countRx != 255) {
+		// switch led on
+		digitalWrite(pinRx, LOW);
+	}
+	else if(!countRx) {
+		// switching off
+		digitalWrite(pinRx, HIGH);
+	}
+	if(countRx != 255)
+		--countRx;
+
+	if(countTx && countTx != 255) {
+		// switch led on
+		digitalWrite(pinTx, LOW);
+	}
+	else if(!countTx) {
+		// switching off
+		digitalWrite(pinTx, HIGH);
+	}
+	if(countTx != 255)
+		--countTx;
+
+	if(countErr && countErr != 255) {
+		// switch led on
+		digitalWrite(pinEr, LOW);
+	}
+	else if(!countErr) {
+		// switching off
+		digitalWrite(pinEr, HIGH);
+	}
+	if(countErr != 255)
+		--countErr;
+}
+
+void MySensor::rxBlink(uint8_t cnt) {
+  if(countRx == 255) { countRx = cnt; }
+}
+
+void MySensor::txBlink(uint8_t cnt) {
+  if(countTx == 255) { countTx = cnt; }
+}
+
+void MySensor::errBlink(uint8_t cnt) {
+  if(countErr == 255) { countErr = cnt; }
+}
+#endif
 
 void MySensor::begin(void (*_msgCallback)(const MyMessage &), uint8_t _nodeId, boolean _repeaterMode, uint8_t _parentNodeId) {
 	hw_init();
@@ -109,6 +173,23 @@ void MySensor::begin(void (*_msgCallback)(const MyMessage &), uint8_t _nodeId, b
 #ifdef MY_SIGNING_FEATURE
 	// Read out the signing requirements from EEPROM
 	hw_readConfigBlock((void*)doSign, (void*)EEPROM_SIGNING_REQUIREMENT_TABLE_ADDRESS, sizeof(doSign));
+#endif
+
+#ifdef WITH_LEDS_BLINKING
+	// Setup led pins
+	pinMode(pinRx, OUTPUT);
+	pinMode(pinTx, OUTPUT);
+	pinMode(pinEr, OUTPUT);
+
+	// Set initial state of leds
+	digitalWrite(pinRx, HIGH);
+	digitalWrite(pinTx, HIGH);
+	digitalWrite(pinEr, HIGH);
+
+	// initialize counters
+	countRx = 0;
+	countTx = 0;
+	countErr = 0;
 #endif
 
 	if (isGateway) {
@@ -408,6 +489,11 @@ void MySensor::requestTime(void (* _timeCallback)(unsigned long)) {
 
 boolean MySensor::process() {
 	hw_watchdogReset();
+
+#ifdef WITH_LEDS_BLINKING
+	handleLedsBlinking();
+#endif
+
 	uint8_t to = 0;
 	if (!radio.available(&to))
 	{

--- a/libraries/MySensors/MySensor.h
+++ b/libraries/MySensors/MySensor.h
@@ -146,6 +146,12 @@ class MySensor
 #ifdef MY_SIGNING_FEATURE
 		, MySigning &signer=*new MySigningNone()
 #endif
+#ifdef WITH_LEDS_BLINKING
+		, uint8_t _rx=DEFAULT_RX_LED_PIN,
+		uint8_t _tx=DEFAULT_TX_LED_PIN,
+		uint8_t _er=DEFAULT_ERR_LED_PIN,
+		unsigned long _blink_period=DEFAULT_LED_BLINK_PERIOD
+#endif
 		);
 
 	/**
@@ -299,6 +305,15 @@ class MySensor
 	 */
 	int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms=0);
 
+#ifdef WITH_LEDS_BLINKING
+	/**
+	 * Blink with LEDs
+	 * @param cnt how many blink cycles to keep the LED on. Default cycle is 300ms
+	 */
+	void rxBlink(uint8_t cnt);
+	void txBlink(uint8_t cnt);
+	void errBlink(uint8_t cnt);
+#endif
 
   protected:
 	NodeConfig nc; // Essential settings for node to work
@@ -322,6 +337,20 @@ class MySensor
 	uint16_t doSign[16]; // Bitfield indicating which sensors require signed communication
 	MyMessage msgSign;  // Buffer for message to sign.
 	MySigning& signer;
+#endif
+
+#ifdef WITH_LEDS_BLINKING
+	uint8_t pinRx; // Rx led pin
+	uint8_t pinTx; // Tx led pin
+	uint8_t pinEr; // Err led pin
+
+	// these variables don't need to be volatile, since we are not using interrupts
+	uint8_t countRx;
+	uint8_t countTx;
+	uint8_t countErr;
+
+	unsigned long ledBlinkPeriod;
+	void handleLedsBlinking(); // do the actual blinking
 #endif
 
 	MyTransport& radio;

--- a/libraries/MySensors/examples/EthernetGateway/EthernetGateway.ino
+++ b/libraries/MySensors/examples/EthernetGateway/EthernetGateway.ino
@@ -46,6 +46,7 @@
  * E.g. If you want to use the defualt values in this sketch enter: 192.168.178.66:5003
  *
  * LED purposes:
+ * - To use the feature, uncomment WITH_LEDS_BLINKING in MyConfig.h
  * - RX (green) - blink fast on radio message recieved. In inclusion mode will blink fast only on presentation recieved
  * - TX (yellow) - blink fast on radio message transmitted. In inclusion mode will blink slowly
  * - ERR (red) - fast blink on error during transmission error or recieve crc error  
@@ -68,7 +69,6 @@
 #include <MyParserSerial.h>  
 #include <MySensor.h>  
 #include <stdarg.h>
-#include <MsTimer2.h>
 #include <PinChangeInt.h>
 #include "GatewayUtil.h"
 
@@ -104,7 +104,12 @@ MyTransportNRF24 transport(RF24_CE_PIN, RF24_CS_PIN, RF24_PA_LEVEL_GW);
 MyHwATMega328 hw;
 
 // Construct MySensors library (signer needed if MY_SIGNING_FEATURE is turned on in MyConfig.h)
+// To use LEDs blinking, uncomment WITH_LEDS_BLINKING in MyConfig.h
+#ifdef WITH_LEDS_BLINKING
+MySensor gw(transport, hw /*, signer*/, RADIO_RX_LED_PIN, RADIO_TX_LED_PIN, RADIO_ERROR_LED_PIN);
+#else
 MySensor gw(transport, hw /*, signer*/);
+#endif
 
 
 #define IP_PORT 5003        // The port you want to open 
@@ -136,11 +141,8 @@ void output(const char *fmt, ... ) {
 void setup()  
 { 
   Ethernet.begin(mac, myIp);
-  setupGateway(RADIO_RX_LED_PIN, RADIO_TX_LED_PIN, RADIO_ERROR_LED_PIN, INCLUSION_MODE_PIN, INCLUSION_MODE_TIME, output);
 
-  // Add led timer interrupt
-  MsTimer2::set(300, ledTimersInterrupt);
-  MsTimer2::start();
+  setupGateway(INCLUSION_MODE_PIN, INCLUSION_MODE_TIME, output);
 
   // Add interrupt for inclusion button to pin
   PCintPort::attachInterrupt(pinInclusion, startInclusionInterrupt, RISING);

--- a/libraries/MySensors/examples/EthernetGateway/GatewayUtil.h
+++ b/libraries/MySensors/examples/EthernetGateway/GatewayUtil.h
@@ -7,9 +7,6 @@
 #ifdef ARDUINO
 
 
-uint8_t pinRx = 8; // Rx led pin
-uint8_t pinTx = 9; // Tx led pin
-uint8_t pinEr = 7; // Err led pin
 uint8_t inclusionTime = 1; // Number of minutes inclusion mode is enabled
 uint8_t pinInclusion =  3; // Input pin that should trigger inclusion mode
 
@@ -17,56 +14,28 @@ uint8_t pinInclusion =  3; // Input pin that should trigger inclusion mode
 #define MAX_SEND_LENGTH 120 // Max buffersize needed for messages destined for controller
 
 volatile boolean buttonTriggeredInclusion;
-volatile uint8_t countRx;
-volatile uint8_t countTx;
-volatile uint8_t countErr;
 boolean inclusionMode; // Keeps track on inclusion mode
 void (*serial)(const char *fmt, ... );
 
 MyParserSerial parser;
 
 void setInclusionMode(boolean newMode);
-void txBlink(uint8_t cnt);
-void rxBlink(uint8_t cnt);
-void errBlink(uint8_t cnt);
 
 char convBuf[MAX_PAYLOAD*2+1];
 char serialBuffer[MAX_SEND_LENGTH]; // Buffer for building string when sending data to vera
 unsigned long inclusionStartTime;
 
-void setupGateway(uint8_t _rx, uint8_t _tx, uint8_t _er, uint8_t _inc, uint8_t _incTime, void (* _serial)(const char *, ... )) {
+void setupGateway(uint8_t _inc, uint8_t _incTime, void (* _serial)(const char *, ... )) {
   inclusionMode = 0;
   buttonTriggeredInclusion = false;
   serial = _serial;
 
-  pinRx = _rx;
-  pinTx = _tx;
-  pinEr = _er;
   pinInclusion = _inc;
   inclusionTime = _incTime;
   
-  countRx = 0;
-  countTx = 0;
-  countErr = 0;
-
-
-  // Setup led pins
-  pinMode(pinRx, OUTPUT);
-  pinMode(pinTx, OUTPUT);
-  pinMode(pinEr, OUTPUT);
-  digitalWrite(pinRx, LOW);
-  digitalWrite(pinTx, LOW);
-  digitalWrite(pinEr, LOW);
-
   // Setup digital in that triggers inclusion mode
   pinMode(pinInclusion, INPUT);
   digitalWrite(pinInclusion, HIGH);
-
-  // Set initial state of leds
-  digitalWrite(pinRx, HIGH);
-  digitalWrite(pinTx, HIGH);
-  digitalWrite(pinEr, HIGH);
-
 }
 
 
@@ -76,11 +45,11 @@ void startInclusionInterrupt() {
 }
 
 void incomingMessage(const MyMessage &message) {
-  if (mGetCommand(message) == C_PRESENTATION && inclusionMode) {
-	rxBlink(3);
-   } else {
-	rxBlink(1);
-   }
+//  if (mGetCommand(message) == C_PRESENTATION && inclusionMode) {
+//	gw.rxBlink(3);
+//   } else {
+//	gw.rxBlink(1);
+//   }
    // Pass along the message from sensors to serial line
    serial(PSTR("%d;%d;%d;%d;%d;%s\n"),message.sender, message.sensor, mGetCommand(message), mGetAck(message), message.type, message.getString(convBuf));
 } 
@@ -106,7 +75,7 @@ void checkInclusionFinished() {
   }
 }
 
-void parseAndSend(MySensor gw, char *commandBuffer) {
+void parseAndSend(MySensor &gw, char *commandBuffer) {
   boolean ok;
   MyMessage &msg = gw.getLastMessage();
 
@@ -123,10 +92,14 @@ void parseAndSend(MySensor gw, char *commandBuffer) {
         setInclusionMode(atoi(msg.data) == 1);
       }
     } else {
-      txBlink(1);
+      #ifdef WITH_LEDS_BLINKING
+      gw.txBlink(1);
+      #endif
       ok = gw.sendRoute(msg);
       if (!ok) {
-        errBlink(1);
+        #ifdef WITH_LEDS_BLINKING
+        gw.errBlink(1);
+        #endif
       }
     }
   }
@@ -143,50 +116,6 @@ void setInclusionMode(boolean newMode) {
     }
   }
 }
-
-
-
-
-void ledTimersInterrupt() {
-  if(countRx && countRx != 255) {
-    // switch led on
-    digitalWrite(pinRx, LOW);
-  } else if(!countRx) {
-     // switching off
-     digitalWrite(pinRx, HIGH);
-   }
-   if(countRx != 255) { countRx--; }
-
-  if(countTx && countTx != 255) {
-    // switch led on
-    digitalWrite(pinTx, LOW);
-  } else if(!countTx) {
-     // switching off
-     digitalWrite(pinTx, HIGH);
-   }
-   if(countTx != 255) { countTx--; }
-   else if(inclusionMode) { countTx = 8; }
-
-  if(countErr && countErr != 255) {
-    // switch led on
-    digitalWrite(pinEr, LOW);
-  } else if(!countErr) {
-     // switching off
-     digitalWrite(pinEr, HIGH);
-   }
-   if(countErr != 255) { countErr--; }
-}
-
-void rxBlink(uint8_t cnt) {
-  if(countRx == 255) { countRx = cnt; }
-}
-void txBlink(uint8_t cnt) {
-  if(countTx == 255 && !inclusionMode) { countTx = cnt; }
-}
-void errBlink(uint8_t cnt) {
-  if(countErr == 255) { countErr = cnt; }
-}
-
 
 
 #else

--- a/libraries/MySensors/examples/SerialGateway/GatewayUtil.h
+++ b/libraries/MySensors/examples/SerialGateway/GatewayUtil.h
@@ -27,9 +27,6 @@
 #ifdef ARDUINO
 
 
-uint8_t pinRx = 8; // Rx led pin
-uint8_t pinTx = 9; // Tx led pin
-uint8_t pinEr = 7; // Err led pin
 uint8_t inclusionTime = 1; // Number of minutes inclusion mode is enabled
 uint8_t pinInclusion =  3; // Input pin that should trigger inclusion mode
 
@@ -37,56 +34,28 @@ uint8_t pinInclusion =  3; // Input pin that should trigger inclusion mode
 #define MAX_SEND_LENGTH 120 // Max buffersize needed for messages destined for controller
 
 volatile boolean buttonTriggeredInclusion;
-volatile uint8_t countRx;
-volatile uint8_t countTx;
-volatile uint8_t countErr;
 boolean inclusionMode; // Keeps track on inclusion mode
 void (*serial)(const char *fmt, ... );
 
 MyParserSerial parser;
 
 void setInclusionMode(boolean newMode);
-void txBlink(uint8_t cnt);
-void rxBlink(uint8_t cnt);
-void errBlink(uint8_t cnt);
 
 char convBuf[MAX_PAYLOAD*2+1];
 char serialBuffer[MAX_SEND_LENGTH]; // Buffer for building string when sending data to vera
 unsigned long inclusionStartTime;
 
-void setupGateway(uint8_t _rx, uint8_t _tx, uint8_t _er, uint8_t _inc, uint8_t _incTime, void (* _serial)(const char *, ... )) {
+void setupGateway(uint8_t _inc, uint8_t _incTime, void (* _serial)(const char *, ... )) {
   inclusionMode = 0;
   buttonTriggeredInclusion = false;
   serial = _serial;
 
-  pinRx = _rx;
-  pinTx = _tx;
-  pinEr = _er;
   pinInclusion = _inc;
   inclusionTime = _incTime;
   
-  countRx = 0;
-  countTx = 0;
-  countErr = 0;
-
-
-  // Setup led pins
-  pinMode(pinRx, OUTPUT);
-  pinMode(pinTx, OUTPUT);
-  pinMode(pinEr, OUTPUT);
-  digitalWrite(pinRx, LOW);
-  digitalWrite(pinTx, LOW);
-  digitalWrite(pinEr, LOW);
-
   // Setup digital in that triggers inclusion mode
   pinMode(pinInclusion, INPUT);
   digitalWrite(pinInclusion, HIGH);
-
-  // Set initial state of leds
-  digitalWrite(pinRx, HIGH);
-  digitalWrite(pinTx, HIGH);
-  digitalWrite(pinEr, HIGH);
-
 }
 
 
@@ -96,11 +65,11 @@ void startInclusionInterrupt() {
 }
 
 void incomingMessage(const MyMessage &message) {
-  if (mGetCommand(message) == C_PRESENTATION && inclusionMode) {
-	rxBlink(3);
-   } else {
-	rxBlink(1);
-   }
+//  if (mGetCommand(message) == C_PRESENTATION && inclusionMode) {
+//	gw.rxBlink(3);
+//   } else {
+//	gw.rxBlink(1);
+//   }
    // Pass along the message from sensors to serial line
    serial(PSTR("%d;%d;%d;%d;%d;%s\n"),message.sender, message.sensor, mGetCommand(message), mGetAck(message), message.type, message.getString(convBuf));
 } 
@@ -126,7 +95,7 @@ void checkInclusionFinished() {
   }
 }
 
-void parseAndSend(MySensor gw, char *commandBuffer) {
+void parseAndSend(MySensor &gw, char *commandBuffer) {
   boolean ok;
   MyMessage &msg = gw.getLastMessage();
 
@@ -143,10 +112,14 @@ void parseAndSend(MySensor gw, char *commandBuffer) {
         setInclusionMode(atoi(msg.data) == 1);
       }
     } else {
-      txBlink(1);
+      #ifdef WITH_LEDS_BLINKING
+      gw.txBlink(1);
+      #endif
       ok = gw.sendRoute(msg);
       if (!ok) {
-        errBlink(1);
+        #ifdef WITH_LEDS_BLINKING
+        gw.errBlink(1);
+        #endif
       }
     }
   }
@@ -163,50 +136,6 @@ void setInclusionMode(boolean newMode) {
     }
   }
 }
-
-
-
-
-void ledTimersInterrupt() {
-  if(countRx && countRx != 255) {
-    // switch led on
-    digitalWrite(pinRx, LOW);
-  } else if(!countRx) {
-     // switching off
-     digitalWrite(pinRx, HIGH);
-   }
-   if(countRx != 255) { countRx--; }
-
-  if(countTx && countTx != 255) {
-    // switch led on
-    digitalWrite(pinTx, LOW);
-  } else if(!countTx) {
-     // switching off
-     digitalWrite(pinTx, HIGH);
-   }
-   if(countTx != 255) { countTx--; }
-   else if(inclusionMode) { countTx = 8; }
-
-  if(countErr && countErr != 255) {
-    // switch led on
-    digitalWrite(pinEr, LOW);
-  } else if(!countErr) {
-     // switching off
-     digitalWrite(pinEr, HIGH);
-   }
-   if(countErr != 255) { countErr--; }
-}
-
-void rxBlink(uint8_t cnt) {
-  if(countRx == 255) { countRx = cnt; }
-}
-void txBlink(uint8_t cnt) {
-  if(countTx == 255 && !inclusionMode) { countTx = cnt; }
-}
-void errBlink(uint8_t cnt) {
-  if(countErr == 255) { countErr = cnt; }
-}
-
 
 
 #else

--- a/libraries/MySensors/examples/SerialGateway/SerialGateway.ino
+++ b/libraries/MySensors/examples/SerialGateway/SerialGateway.ino
@@ -29,6 +29,7 @@
  * - RX/TX/ERR leds need to be connected between +5V (anode) and digital pin 6/5/4 with resistor 270-330R in a series
  *
  * LEDs (OPTIONAL):
+ * - To use the feature, uncomment WITH_LEDS_BLINKING in MyConfig.h
  * - RX (green) - blink fast on radio message recieved. In inclusion mode will blink fast only on presentation recieved
  * - TX (yellow) - blink fast on radio message transmitted. In inclusion mode will blink slowly
  * - ERR (red) - fast blink on error during transmission error or recieve crc error 
@@ -48,7 +49,6 @@
 #include <MyParserSerial.h>  
 #include <MySensor.h>  
 #include <stdarg.h>
-#include <MsTimer2.h>
 #include <PinChangeInt.h>
 #include "GatewayUtil.h"
 
@@ -59,7 +59,7 @@
 #define RADIO_TX_LED_PIN    5  // the PCB, on board LED
 
 // NRFRF24L01 radio driver (set low transmit power by default) 
-MyTransportNRF24 transport(RF24_CE_PIN, RF24_CS_PIN, RF24_PA_LEVEL_GW);  
+MyTransportNRF24 transport(RF24_CE_PIN, RF24_CS_PIN, RF24_PA_LEVEL_GW);
 //MyTransportRFM69 transport;
 
 // Message signing driver (signer needed if MY_SIGNING_FEATURE is turned on in MyConfig.h)
@@ -71,7 +71,12 @@ MyTransportNRF24 transport(RF24_CE_PIN, RF24_CS_PIN, RF24_PA_LEVEL_GW);
 MyHwATMega328 hw;
 
 // Construct MySensors library (signer needed if MY_SIGNING_FEATURE is turned on in MyConfig.h)
+// To use LEDs blinking, uncomment WITH_LEDS_BLINKING in MyConfig.h
+#ifdef WITH_LEDS_BLINKING
+MySensor gw(transport, hw /*, signer*/, RADIO_RX_LED_PIN, RADIO_TX_LED_PIN, RADIO_ERROR_LED_PIN);
+#else
 MySensor gw(transport, hw /*, signer*/);
+#endif
 
 char inputString[MAX_RECEIVE_LENGTH] = "";    // A string to hold incoming commands from serial/ethernet interface
 int inputPos = 0;
@@ -92,11 +97,7 @@ void setup()
 { 
   gw.begin(incomingMessage, 0, true, 0);
 
-  setupGateway(RADIO_RX_LED_PIN, RADIO_TX_LED_PIN, RADIO_ERROR_LED_PIN, INCLUSION_MODE_PIN, INCLUSION_MODE_TIME, output);  
-
-  // Add led timer interrupt
-  MsTimer2::set(300, ledTimersInterrupt);
-  MsTimer2::start();
+  setupGateway(INCLUSION_MODE_PIN, INCLUSION_MODE_TIME, output);
 
   // Add interrupt for inclusion button to pin
   PCintPort::attachInterrupt(pinInclusion, startInclusionInterrupt, RISING);


### PR DESCRIPTION
Hi.

As we discussed in PR #66 I added the possibility to blink LEDs into the base MySensor class. I tested it with simple temperature sensor based on Arduino Mini Pro and with Serial Gateway. I also modified the Ethernet Gateway. I left the MQTT gateway as is, since I don't have testing setup for MQTT and the Gateway is not using the common GatewayUtil.h as the other two gateways.

Next step... move the inclusion mode feature into the base class (most probably reintroduced MyGateway class) without the interrupts library. And then finally rebase the dynamic discovery ;)