### PR TITLE
Make sure SPI backend is initialized in SPIFlash driver

### DIFF
--- a/libraries/MySensors/utility/SPIFlash.cpp
+++ b/libraries/MySensors/utility/SPIFlash.cpp
@@ -56,6 +56,7 @@ void SPIFlash::unselect() {
 /// setup SPI, read device ID etc...
 boolean SPIFlash::initialize()
 {
+  SPI.begin();
   _SPCR = SPCR;
   _SPSR = SPSR;
   pinMode(_slaveSelectPin, OUTPUT);


### PR DESCRIPTION
In some cases, SPIFlash driver hangs during initialization
because it reads data from the SPI backend. But if SPI backend
has not been initialized, this fails.