### PR TITLE
Non-blocking Dallas sensors temperature conversion

### DIFF
--- a/libraries/DallasTemperature/DallasTemperature.cpp
+++ b/libraries/DallasTemperature/DallasTemperature.cpp
@@ -3,369 +3,491 @@
 // License as published by the Free Software Foundation; either
 // version 2.1 of the License, or (at your option) any later version.
 
+// Version 3.7.2 modified on Dec 6, 2011 to support Arduino 1.0
+// See Includes...
+// Modified by Jordan Hochenbaum
+
 #include "DallasTemperature.h"
 
+#if ARDUINO >= 100
+#include "Arduino.h"
+#else
 extern "C" {
-  #include "Arduino.h"
+#include "WConstants.h"
 }
+#endif
 
 DallasTemperature::DallasTemperature(OneWire* _oneWire)
-  #if REQUIRESALARMS
-  : _AlarmHandler(&defaultAlarmHandler)
-  #endif
+#if REQUIRESALARMS
+    : _AlarmHandler(&defaultAlarmHandler)
+#endif
 {
-  _wire = _oneWire;
-  devices = 0;
-  parasite = false;
-  conversionDelay = TEMP_9_BIT;
+    _wire = _oneWire;
+    devices = 0;
+    parasite = false;
+    bitResolution = 9;
+    waitForConversion = true;
+    checkForConversion = true;
 }
 
-// initialize the bus
+// initialise the bus
 void DallasTemperature::begin(void)
 {
-  DeviceAddress deviceAddress;
+    DeviceAddress deviceAddress;
 
-  _wire->reset_search();
-  devices = 0; // Reset the number of devices when we enumerate wire devices
+    _wire->reset_search();
+    devices = 0; // Reset the number of devices when we enumerate wire devices
 
-  while (_wire->search(deviceAddress))
-  {
-    if (validAddress(deviceAddress))
+    while (_wire->search(deviceAddress))
     {
-      if (!parasite && readPowerSupply(deviceAddress)) parasite = true;
+        if (validAddress(deviceAddress))
+        {
+            if (!parasite && readPowerSupply(deviceAddress)) parasite = true;
 
-      ScratchPad scratchPad;
+            ScratchPad scratchPad;
 
-      readScratchPad(deviceAddress, scratchPad);
+            readScratchPad(deviceAddress, scratchPad);
 
-      if (deviceAddress[0] == DS18S20MODEL) conversionDelay = TEMP_12_BIT; // 750 ms
-      else if (scratchPad[CONFIGURATION] > conversionDelay) conversionDelay = scratchPad[CONFIGURATION];
+            bitResolution = max(bitResolution, getResolution(deviceAddress));
 
-      devices++;
+            devices++;
+        }
     }
-  }
 }
 
 // returns the number of devices found on the bus
 uint8_t DallasTemperature::getDeviceCount(void)
 {
-  return devices;
+    return devices;
 }
 
 // returns true if address is valid
-bool DallasTemperature::validAddress(uint8_t* deviceAddress)
+bool DallasTemperature::validAddress(const uint8_t* deviceAddress)
 {
-  return (_wire->crc8(deviceAddress, 7) == deviceAddress[7]);
+    return (_wire->crc8(deviceAddress, 7) == deviceAddress[7]);
 }
 
 // finds an address at a given index on the bus
 // returns true if the device was found
 bool DallasTemperature::getAddress(uint8_t* deviceAddress, uint8_t index)
 {
-  uint8_t depth = 0;
+    uint8_t depth = 0;
 
-  _wire->reset_search();
+    _wire->reset_search();
 
-  while (depth <= index && _wire->search(deviceAddress))
-  {
-    if (depth == index && validAddress(deviceAddress)) return true;
-    depth++;
-  }
+    while (depth <= index && _wire->search(deviceAddress))
+    {
+        if (depth == index && validAddress(deviceAddress)) return true;
+        depth++;
+    }
 
-  return false;
+    return false;
 }
 
 // attempt to determine if the device at the given address is connected to the bus
-bool DallasTemperature::isConnected(uint8_t* deviceAddress)
+bool DallasTemperature::isConnected(const uint8_t* deviceAddress)
 {
-  ScratchPad scratchPad;
-  return isConnected(deviceAddress, scratchPad);
+    ScratchPad scratchPad;
+    return isConnected(deviceAddress, scratchPad);
 }
 
 // attempt to determine if the device at the given address is connected to the bus
 // also allows for updating the read scratchpad
-bool DallasTemperature::isConnected(uint8_t* deviceAddress, uint8_t* scratchPad)
+bool DallasTemperature::isConnected(const uint8_t* deviceAddress, uint8_t* scratchPad)
 {
-  readScratchPad(deviceAddress, scratchPad);
-  return (_wire->crc8(scratchPad, 8) == scratchPad[SCRATCHPAD_CRC]);
+    readScratchPad(deviceAddress, scratchPad);
+    return (_wire->crc8(scratchPad, 8) == scratchPad[SCRATCHPAD_CRC]);
 }
 
 // read device's scratch pad
-void DallasTemperature::readScratchPad(uint8_t* deviceAddress, uint8_t* scratchPad)
+void DallasTemperature::readScratchPad(const uint8_t* deviceAddress, uint8_t* scratchPad)
 {
-  // send the command
-  _wire->reset();
-  _wire->select(deviceAddress);
-  _wire->write(READSCRATCH);
+    // send the command
+    _wire->reset();
+    _wire->select(deviceAddress);
+    _wire->write(READSCRATCH);
 
-  // read the response
+    // TODO => collect all comments &  use simple loop
+    // byte 0: temperature LSB
+    // byte 1: temperature MSB
+    // byte 2: high alarm temp
+    // byte 3: low alarm temp
+    // byte 4: DS18S20: store for crc
+    //         DS18B20 & DS1822: configuration register
+    // byte 5: internal use & crc
+    // byte 6: DS18S20: COUNT_REMAIN
+    //         DS18B20 & DS1822: store for crc
+    // byte 7: DS18S20: COUNT_PER_C
+    //         DS18B20 & DS1822: store for crc
+    // byte 8: SCRATCHPAD_CRC
+    //
+    // for(int i=0; i<9; i++)
+    // {
+    //   scratchPad[i] = _wire->read();
+    // }
 
-  // byte 0: temperature LSB
-  scratchPad[TEMP_LSB] = _wire->read();
 
-  // byte 1: temperature MSB
-  scratchPad[TEMP_MSB] = _wire->read();
+    // read the response
 
-  // byte 2: high alarm temp
-  scratchPad[HIGH_ALARM_TEMP] = _wire->read();
+    // byte 0: temperature LSB
+    scratchPad[TEMP_LSB] = _wire->read();
 
-  // byte 3: low alarm temp
-  scratchPad[LOW_ALARM_TEMP] = _wire->read();
+    // byte 1: temperature MSB
+    scratchPad[TEMP_MSB] = _wire->read();
 
-  // byte 4:
-  // DS18S20: store for crc
-  // DS18B20 & DS1822: configuration register
-  scratchPad[CONFIGURATION] = _wire->read();
+    // byte 2: high alarm temp
+    scratchPad[HIGH_ALARM_TEMP] = _wire->read();
 
-  // byte 5:
-  // internal use & crc
-  scratchPad[INTERNAL_BYTE] = _wire->read();
+    // byte 3: low alarm temp
+    scratchPad[LOW_ALARM_TEMP] = _wire->read();
 
-  // byte 6:
-  // DS18S20: COUNT_REMAIN
-  // DS18B20 & DS1822: store for crc
-  scratchPad[COUNT_REMAIN] = _wire->read();
+    // byte 4:
+    // DS18S20: store for crc
+    // DS18B20 & DS1822: configuration register
+    scratchPad[CONFIGURATION] = _wire->read();
 
-  // byte 7:
-  // DS18S20: COUNT_PER_C
-  // DS18B20 & DS1822: store for crc
-  scratchPad[COUNT_PER_C] = _wire->read();
+    // byte 5:
+    // internal use & crc
+    scratchPad[INTERNAL_BYTE] = _wire->read();
 
-  // byte 8:
-  // SCTRACHPAD_CRC
-  scratchPad[SCRATCHPAD_CRC] = _wire->read();
+    // byte 6:
+    // DS18S20: COUNT_REMAIN
+    // DS18B20 & DS1822: store for crc
+    scratchPad[COUNT_REMAIN] = _wire->read();
 
-  _wire->reset();
+    // byte 7:
+    // DS18S20: COUNT_PER_C
+    // DS18B20 & DS1822: store for crc
+    scratchPad[COUNT_PER_C] = _wire->read();
+
+    // byte 8:
+    // SCTRACHPAD_CRC
+    scratchPad[SCRATCHPAD_CRC] = _wire->read();
+
+    _wire->reset();
 }
 
 // writes device's scratch pad
-void DallasTemperature::writeScratchPad(uint8_t* deviceAddress, const uint8_t* scratchPad)
+void DallasTemperature::writeScratchPad(const uint8_t* deviceAddress, const uint8_t* scratchPad)
 {
-  _wire->reset();
-  _wire->select(deviceAddress);
-  _wire->write(WRITESCRATCH);
-  _wire->write(scratchPad[HIGH_ALARM_TEMP]); // high alarm temp
-  _wire->write(scratchPad[LOW_ALARM_TEMP]); // low alarm temp
-  // DS18S20 does not use the configuration register
-  if (deviceAddress[0] != DS18S20MODEL) _wire->write(scratchPad[CONFIGURATION]); // configuration
-  _wire->reset();
-  // save the newly written values to eeprom
-  _wire->write(COPYSCRATCH, parasite);
-  if (parasite) delay(10); // 10ms delay
-  _wire->reset();
+    _wire->reset();
+    _wire->select(deviceAddress);
+    _wire->write(WRITESCRATCH);
+    _wire->write(scratchPad[HIGH_ALARM_TEMP]); // high alarm temp
+    _wire->write(scratchPad[LOW_ALARM_TEMP]); // low alarm temp
+    // DS1820 and DS18S20 have no configuration register
+    if (deviceAddress[0] != DS18S20MODEL) _wire->write(scratchPad[CONFIGURATION]); // configuration
+    _wire->reset();
+    _wire->select(deviceAddress); //<--this line was missing
+    // save the newly written values to eeprom
+    _wire->write(COPYSCRATCH, parasite);
+    delay(20);  // <--- added 20ms delay to allow 10ms long EEPROM write operation (as specified by datasheet) 
+    if (parasite) delay(10); // 10ms delay
+    _wire->reset();
 }
 
 // reads the device's power requirements
-bool DallasTemperature::readPowerSupply(uint8_t* deviceAddress)
+bool DallasTemperature::readPowerSupply(const uint8_t* deviceAddress)
 {
-  bool ret = false;
-  _wire->reset();
-  _wire->select(deviceAddress);
-  _wire->write(READPOWERSUPPLY);
-  if (_wire->read_bit() == 0) ret = true;
-  _wire->reset();
-  return ret;
+    bool ret = false;
+    _wire->reset();
+    _wire->select(deviceAddress);
+    _wire->write(READPOWERSUPPLY);
+    if (_wire->read_bit() == 0) ret = true;
+    _wire->reset();
+    return ret;
 }
 
-// returns the current resolution, 9-12
-uint8_t DallasTemperature::getResolution(uint8_t* deviceAddress)
-{
-  if (deviceAddress[0] == DS18S20MODEL) return 9; // this model has a fixed resolution
 
-  ScratchPad scratchPad;
-  readScratchPad(deviceAddress, scratchPad);
-  switch (scratchPad[CONFIGURATION])
-  {
-    case TEMP_12_BIT:
-      return 12;
-      break;
-    case TEMP_11_BIT:
-      return 11;
-      break;
-    case TEMP_10_BIT:
-      return 10;
-      break;
-    case TEMP_9_BIT:
-      return 9;
-      break;
-  }
+// set resolution of all devices to 9, 10, 11, or 12 bits
+// if new resolution is out of range, it is constrained.
+void DallasTemperature::setResolution(uint8_t newResolution)
+{
+    bitResolution = constrain(newResolution, 9, 12);
+    DeviceAddress deviceAddress;
+    for (int i=0; i<devices; i++)
+    {
+        getAddress(deviceAddress, i);
+        setResolution(deviceAddress, bitResolution);
+    }
 }
 
 // set resolution of a device to 9, 10, 11, or 12 bits
-void DallasTemperature::setResolution(uint8_t* deviceAddress, uint8_t newResolution)
+// if new resolution is out of range, 9 bits is used.
+bool DallasTemperature::setResolution(const uint8_t* deviceAddress, uint8_t newResolution)
 {
-  ScratchPad scratchPad;
-  if (isConnected(deviceAddress, scratchPad))
-  {
-    // DS18S20 has a fixed 9-bit resolution
-    if (deviceAddress[0] != DS18S20MODEL)
+    ScratchPad scratchPad;
+    if (isConnected(deviceAddress, scratchPad))
     {
-      switch (newResolution)
-      {
-        case 12:
-          scratchPad[CONFIGURATION] = TEMP_12_BIT;
-          break;
-        case 11:
-          scratchPad[CONFIGURATION] = TEMP_11_BIT;
-          break;
-        case 10:
-          scratchPad[CONFIGURATION] = TEMP_10_BIT;
-          break;
-        case 9:
-        default:
-          scratchPad[CONFIGURATION] = TEMP_9_BIT;
-          break;
-      }
-      writeScratchPad(deviceAddress, scratchPad);
+        // DS1820 and DS18S20 have no resolution configuration register
+        if (deviceAddress[0] != DS18S20MODEL)
+        {
+            switch (newResolution)
+            {
+            case 12:
+                scratchPad[CONFIGURATION] = TEMP_12_BIT;
+                break;
+            case 11:
+                scratchPad[CONFIGURATION] = TEMP_11_BIT;
+                break;
+            case 10:
+                scratchPad[CONFIGURATION] = TEMP_10_BIT;
+                break;
+            case 9:
+            default:
+                scratchPad[CONFIGURATION] = TEMP_9_BIT;
+                break;
+            }
+            writeScratchPad(deviceAddress, scratchPad);
+        }
+        return true;  // new value set
     }
-  }
+    return false;
 }
 
-// sends command for all devices on the bus to perform a temperature
-void DallasTemperature::requestTemperatures(void)
+// returns the global resolution
+uint8_t DallasTemperature::getResolution()
 {
-  _wire->reset();
-  _wire->skip();
-  _wire->write(STARTCONVO, parasite);
+    return bitResolution;
+}
 
-  switch (conversionDelay)
-  {
-    case TEMP_9_BIT:
-      delay(94);
-      break;
-    case TEMP_10_BIT:
-      delay(188);
-      break;
-    case TEMP_11_BIT:
-      delay(375);
-      break;
-    case TEMP_12_BIT:
-    default:
-      delay(750);
-      break;
-  }
+// returns the current resolution of the device, 9-12
+// returns 0 if device not found
+uint8_t DallasTemperature::getResolution(const uint8_t* deviceAddress)
+{
+    // DS1820 and DS18S20 have no resolution configuration register
+    if (deviceAddress[0] == DS18S20MODEL) return 12;
+
+    ScratchPad scratchPad;
+    if (isConnected(deviceAddress, scratchPad))
+    {
+        switch (scratchPad[CONFIGURATION])
+        {
+        case TEMP_12_BIT:
+            return 12;
+
+        case TEMP_11_BIT:
+            return 11;
+
+        case TEMP_10_BIT:
+            return 10;
+
+        case TEMP_9_BIT:
+            return 9;
+        }
+    }
+    return 0;
+}
+
+
+// sets the value of the waitForConversion flag
+// TRUE : function requestTemperature() etc returns when conversion is ready
+// FALSE: function requestTemperature() etc returns immediately (USE WITH CARE!!)
+//        (1) programmer has to check if the needed delay has passed
+//        (2) but the application can do meaningful things in that time
+void DallasTemperature::setWaitForConversion(bool flag)
+{
+    waitForConversion = flag;
+}
+
+// gets the value of the waitForConversion flag
+bool DallasTemperature::getWaitForConversion()
+{
+    return waitForConversion;
+}
+
+
+// sets the value of the checkForConversion flag
+// TRUE : function requestTemperature() etc will 'listen' to an IC to determine whether a conversion is complete
+// FALSE: function requestTemperature() etc will wait a set time (worst case scenario) for a conversion to complete
+void DallasTemperature::setCheckForConversion(bool flag)
+{
+    checkForConversion = flag;
+}
+
+// gets the value of the waitForConversion flag
+bool DallasTemperature::getCheckForConversion()
+{
+    return checkForConversion;
+}
+
+bool DallasTemperature::isConversionAvailable(const uint8_t* deviceAddress)
+{
+    // Check if the clock has been raised indicating the conversion is complete
+    ScratchPad scratchPad;
+    readScratchPad(deviceAddress, scratchPad);
+    return scratchPad[0];
+}
+
+
+// sends command for all devices on the bus to perform a temperature conversion
+void DallasTemperature::requestTemperatures()
+{
+    _wire->reset();
+    _wire->skip();
+    _wire->write(STARTCONVO, parasite);
+
+    // ASYNC mode?
+    if (!waitForConversion) return;
+    blockTillConversionComplete(bitResolution, NULL);
 }
 
 // sends command for one device to perform a temperature by address
-void DallasTemperature::requestTemperaturesByAddress(uint8_t* deviceAddress)
+// returns FALSE if device is disconnected
+// returns TRUE  otherwise
+bool DallasTemperature::requestTemperaturesByAddress(const uint8_t* deviceAddress)
 {
-  _wire->reset();
-  _wire->select(deviceAddress);
-  _wire->write(STARTCONVO, parasite);
+    _wire->reset();
+    _wire->select(deviceAddress);
+    _wire->write(STARTCONVO, parasite);
 
-  switch (conversionDelay)
-  {
-    case TEMP_9_BIT:
-      delay(94);
-      break;
-    case TEMP_10_BIT:
-      delay(188);
-      break;
-    case TEMP_11_BIT:
-      delay(375);
-      break;
-    case TEMP_12_BIT:
+    // check device
+    ScratchPad scratchPad;
+    if (!isConnected(deviceAddress, scratchPad)) return false;
+
+    // ASYNC mode?
+    if (!waitForConversion) return true;
+    blockTillConversionComplete(getResolution(deviceAddress), deviceAddress);
+
+    return true;
+}
+
+// returns number of milliseconds to wait till conversion is complete (based on IC datasheet)
+int16_t DallasTemperature::millisToWaitForConversion(uint8_t bitResolution)
+{
+    switch (bitResolution)
+    {
+    case 9:
+        return 94;
+    case 10:
+        return 188;
+    case 11:
+        return 375;
     default:
-      delay(750);
-      break;
-  }
+        return 750;
+    }
+}
+
+// Continue to check if the IC has responded with a temperature
+void DallasTemperature::blockTillConversionComplete(uint8_t bitResolution, const uint8_t* deviceAddress)
+{
+    int delms = millisToWaitForConversion(bitResolution);
+    if (deviceAddress != NULL && checkForConversion && !parasite)
+    {
+        unsigned long timend = millis() + delms;
+        while(!isConversionAvailable(deviceAddress) && (millis() < timend));
+    }
+    else
+    {
+        delay(delms);
+    }
 }
 
 // sends command for one device to perform a temp conversion by index
-void DallasTemperature::requestTemperaturesByIndex(uint8_t deviceIndex)
+bool DallasTemperature::requestTemperaturesByIndex(uint8_t deviceIndex)
 {
-  DeviceAddress deviceAddress;
-  getAddress(deviceAddress, deviceIndex);
-  requestTemperaturesByAddress(deviceAddress);
+    DeviceAddress deviceAddress;
+    getAddress(deviceAddress, deviceIndex);
+    return requestTemperaturesByAddress(deviceAddress);
 }
-
 
 // Fetch temperature for device index
 float DallasTemperature::getTempCByIndex(uint8_t deviceIndex)
 {
-  DeviceAddress deviceAddress;
-  getAddress(deviceAddress, deviceIndex);
-  return getTempC((uint8_t*)deviceAddress);
+    DeviceAddress deviceAddress;
+    if (!getAddress(deviceAddress, deviceIndex))
+        return DEVICE_DISCONNECTED_C;
+    return getTempC((uint8_t*)deviceAddress);
 }
 
 // Fetch temperature for device index
 float DallasTemperature::getTempFByIndex(uint8_t deviceIndex)
 {
-  return DallasTemperature::toFahrenheit(getTempCByIndex(deviceIndex));
+    DeviceAddress deviceAddress;
+    if (!getAddress(deviceAddress, deviceIndex))
+        return DEVICE_DISCONNECTED_F;
+    return getTempF((uint8_t*)deviceAddress);
 }
 
-// reads scratchpad and returns the temperature in degrees C
-float DallasTemperature::calculateTemperature(uint8_t* deviceAddress, uint8_t* scratchPad)
+// reads scratchpad and returns fixed-point temperature, scaling factor 2^-7
+int16_t DallasTemperature::calculateTemperature(const uint8_t* deviceAddress, uint8_t* scratchPad)
 {
-  int16_t rawTemperature = (((int16_t)scratchPad[TEMP_MSB]) << 8) | scratchPad[TEMP_LSB];
+    int16_t fpTemperature =
+        (((int16_t) scratchPad[TEMP_MSB]) << 11) |
+        (((int16_t) scratchPad[TEMP_LSB]) << 3);
 
-  switch (deviceAddress[0])
-  {
-    case DS18B20MODEL:
-    case DS1822MODEL:
-      switch (scratchPad[CONFIGURATION])
-      {
-        case TEMP_12_BIT:
-          return (float)rawTemperature * 0.0625;
-          break;
-        case TEMP_11_BIT:
-          return (float)(rawTemperature >> 1) * 0.125;
-          break;
-        case TEMP_10_BIT:
-          return (float)(rawTemperature >> 2) * 0.25;
-          break;
-        case TEMP_9_BIT:
-          return (float)(rawTemperature >> 3) * 0.5;
-          break;
-      }
-      break;
-    case DS18S20MODEL:
-      /*
+    /*
+    DS1820 and DS18S20 have a 9-bit temperature register.
 
-      Resolutions greater than 9 bits can be calculated using the data from
-      the temperature, COUNT REMAIN and COUNT PER °C registers in the
-      scratchpad. Note that the COUNT PER °C register is hard-wired to 16
-      (10h). After reading the scratchpad, the TEMP_READ value is obtained
-      by truncating the 0.5°C bit (bit 0) from the temperature data. The
-      extended resolution temperature can then be calculated using the
-      following equation:
+    Resolutions greater than 9-bit can be calculated using the data from
+    the temperature, and COUNT REMAIN and COUNT PER Â°C registers in the
+    scratchpad.  The resolution of the calculation depends on the model.
 
-                                       COUNT_PER_C - COUNT_REMAIN
-      TEMPERATURE = TEMP_READ - 0.25 + --------------------------
-                                               COUNT_PER_C
-      */
+    While the COUNT PER Â°C register is hard-wired to 16 (10h) in a
+    DS18S20, it changes with temperature in DS1820.
 
-      // Good spot. Thanks Nic Johns for your contribution
-      return (float)(rawTemperature >> 1) - 0.25 +((float)(scratchPad[COUNT_PER_C] - scratchPad[COUNT_REMAIN]) / (float)scratchPad[COUNT_PER_C] );
-      break;
-  }
+    After reading the scratchpad, the TEMP_READ value is obtained by
+    truncating the 0.5Â°C bit (bit 0) from the temperature data. The
+    extended resolution temperature can then be calculated using the
+    following equation:
+
+                                    COUNT_PER_C - COUNT_REMAIN
+    TEMPERATURE = TEMP_READ - 0.25 + --------------------------
+                                            COUNT_PER_C
+
+    Hagai Shatz simplified this to integer arithmetic for a 12 bits
+    value for a DS18S20, and James Cameron added legacy DS1820 support.
+
+    See - http://myarduinotoy.blogspot.co.uk/2013/02/12bit-result-from-ds18s20.html
+    */
+
+    if (deviceAddress[0] == DS18S20MODEL)
+        fpTemperature = ((fpTemperature & 0xfff0) << 3) - 16 +
+            (
+                ((scratchPad[COUNT_PER_C] - scratchPad[COUNT_REMAIN]) << 7) /
+                  scratchPad[COUNT_PER_C]
+            );
+
+    return fpTemperature;
 }
 
-// returns temperature in degrees C or DEVICE_DISCONNECTED if the
+
+// returns temperature in 1/128 degrees C or DEVICE_DISCONNECTED_RAW if the
 // device's scratch pad cannot be read successfully.
-// the numeric value of DEVICE_DISCONNECTED is defined in
-// DallasTemperature.h.  it is a large negative number outside the
+// the numeric value of DEVICE_DISCONNECTED_RAW is defined in
+// DallasTemperature.h. It is a large negative number outside the
 // operating range of the device
-float DallasTemperature::getTempC(uint8_t* deviceAddress)
+int16_t DallasTemperature::getTemp(const uint8_t* deviceAddress)
 {
-  // TODO: Multiple devices (up to 64) on the same bus may take some time to negotiate a response
-  // What happens in case of collision?
-
-  ScratchPad scratchPad;
-  if (isConnected(deviceAddress, scratchPad)) return calculateTemperature(deviceAddress, scratchPad);
-  return DEVICE_DISCONNECTED;
+    ScratchPad scratchPad;
+    if (isConnected(deviceAddress, scratchPad)) return calculateTemperature(deviceAddress, scratchPad);
+    return DEVICE_DISCONNECTED_RAW;
 }
 
-// returns temperature in degrees F
-float DallasTemperature::getTempF(uint8_t* deviceAddress)
+// returns temperature in degrees C or DEVICE_DISCONNECTED_C if the
+// device's scratch pad cannot be read successfully.
+// the numeric value of DEVICE_DISCONNECTED_C is defined in
+// DallasTemperature.h. It is a large negative number outside the
+// operating range of the device
+float DallasTemperature::getTempC(const uint8_t* deviceAddress)
 {
-  return toFahrenheit(getTempC(deviceAddress));
+    return rawToCelsius(getTemp(deviceAddress));
+}
+
+// returns temperature in degrees F or DEVICE_DISCONNECTED_F if the
+// device's scratch pad cannot be read successfully.
+// the numeric value of DEVICE_DISCONNECTED_F is defined in
+// DallasTemperature.h. It is a large negative number outside the
+// operating range of the device
+float DallasTemperature::getTempF(const uint8_t* deviceAddress)
+{
+    return rawToFahrenheit(getTemp(deviceAddress));
 }
 
 // returns true if the bus requires parasite power
 bool DallasTemperature::isParasitePowerMode(void)
 {
-  return parasite;
+    return parasite;
 }
 
 #if REQUIRESALARMS
@@ -390,65 +512,65 @@ the next temperature conversion.
 
 */
 
-// sets the high alarm temperature for a device in degrees celsius
+// sets the high alarm temperature for a device in degrees Celsius
 // accepts a float, but the alarm resolution will ignore anything
 // after a decimal point.  valid range is -55C - 125C
-void DallasTemperature::setHighAlarmTemp(uint8_t* deviceAddress, char celsius)
+void DallasTemperature::setHighAlarmTemp(const uint8_t* deviceAddress, char celsius)
 {
-  // make sure the alarm temperature is within the device's range
-  if (celsius > 125) celsius = 125;
-  else if (celsius < -55) celsius = -55;
+    // make sure the alarm temperature is within the device's range
+    if (celsius > 125) celsius = 125;
+    else if (celsius < -55) celsius = -55;
 
-  ScratchPad scratchPad;
-  if (isConnected(deviceAddress, scratchPad))
-  {
-    scratchPad[HIGH_ALARM_TEMP] = (uint8_t)celsius;
-    writeScratchPad(deviceAddress, scratchPad);
-  }
+    ScratchPad scratchPad;
+    if (isConnected(deviceAddress, scratchPad))
+    {
+        scratchPad[HIGH_ALARM_TEMP] = (uint8_t)celsius;
+        writeScratchPad(deviceAddress, scratchPad);
+    }
 }
 
-// sets the low alarm temperature for a device in degreed celsius
+// sets the low alarm temperature for a device in degrees Celsius
 // accepts a float, but the alarm resolution will ignore anything
 // after a decimal point.  valid range is -55C - 125C
-void DallasTemperature::setLowAlarmTemp(uint8_t* deviceAddress, char celsius)
+void DallasTemperature::setLowAlarmTemp(const uint8_t* deviceAddress, char celsius)
 {
-  // make sure the alarm temperature is within the device's range
-  if (celsius > 125) celsius = 125;
-  else if (celsius < -55) celsius = -55;
+    // make sure the alarm temperature is within the device's range
+    if (celsius > 125) celsius = 125;
+    else if (celsius < -55) celsius = -55;
 
-  ScratchPad scratchPad;
-  if (isConnected(deviceAddress, scratchPad))
-  {
-    scratchPad[LOW_ALARM_TEMP] = (uint8_t)celsius;
-    writeScratchPad(deviceAddress, scratchPad);
-  }
+    ScratchPad scratchPad;
+    if (isConnected(deviceAddress, scratchPad))
+    {
+        scratchPad[LOW_ALARM_TEMP] = (uint8_t)celsius;
+        writeScratchPad(deviceAddress, scratchPad);
+    }
 }
 
 // returns a char with the current high alarm temperature or
 // DEVICE_DISCONNECTED for an address
-char DallasTemperature::getHighAlarmTemp(uint8_t* deviceAddress)
+char DallasTemperature::getHighAlarmTemp(const uint8_t* deviceAddress)
 {
-  ScratchPad scratchPad;
-  if (isConnected(deviceAddress, scratchPad)) return (char)scratchPad[HIGH_ALARM_TEMP];
-  return DEVICE_DISCONNECTED;
+    ScratchPad scratchPad;
+    if (isConnected(deviceAddress, scratchPad)) return (char)scratchPad[HIGH_ALARM_TEMP];
+    return DEVICE_DISCONNECTED_C;
 }
 
 // returns a char with the current low alarm temperature or
 // DEVICE_DISCONNECTED for an address
-char DallasTemperature::getLowAlarmTemp(uint8_t* deviceAddress)
+char DallasTemperature::getLowAlarmTemp(const uint8_t* deviceAddress)
 {
-  ScratchPad scratchPad;
-  if (isConnected(deviceAddress, scratchPad)) return (char)scratchPad[LOW_ALARM_TEMP];
-  return DEVICE_DISCONNECTED;
+    ScratchPad scratchPad;
+    if (isConnected(deviceAddress, scratchPad)) return (char)scratchPad[LOW_ALARM_TEMP];
+    return DEVICE_DISCONNECTED_C;
 }
 
 // resets internal variables used for the alarm search
 void DallasTemperature::resetAlarmSearch()
 {
-  alarmSearchJunction = -1;
-  alarmSearchExhausted = 0;
-  for(uint8_t i = 0; i < 7; i++)
-    alarmSearchAddress[i] = 0;
+    alarmSearchJunction = -1;
+    alarmSearchExhausted = 0;
+    for(uint8_t i = 0; i < 7; i++)
+        alarmSearchAddress[i] = 0;
 }
 
 // This is a modified version of the OneWire::search method.
@@ -465,132 +587,152 @@ void DallasTemperature::resetAlarmSearch()
 // DallasTemperature::resetAlarmSearch() to start over.
 bool DallasTemperature::alarmSearch(uint8_t* newAddr)
 {
-  uint8_t i;
-  char lastJunction = -1;
-  uint8_t done = 1;
+    uint8_t i;
+    char lastJunction = -1;
+    uint8_t done = 1;
 
-  if (alarmSearchExhausted) return false;
-  if (!_wire->reset()) return false;
+    if (alarmSearchExhausted) return false;
+    if (!_wire->reset()) return false;
 
-  // send the alarm search command
-  _wire->write(0xEC, 0);
+    // send the alarm search command
+    _wire->write(0xEC, 0);
 
-  for(i = 0; i < 64; i++)
-  {
-    uint8_t a = _wire->read_bit( );
-    uint8_t nota = _wire->read_bit( );
-    uint8_t ibyte = i / 8;
-    uint8_t ibit = 1 << (i & 7);
-
-    // I don't think this should happen, this means nothing responded, but maybe if
-    // something vanishes during the search it will come up.
-    if (a && nota) return false;
-
-    if (!a && !nota)
+    for(i = 0; i < 64; i++)
     {
-      if (i == alarmSearchJunction)
-      {
-        // this is our time to decide differently, we went zero last time, go one.
-        a = 1;
-        alarmSearchJunction = lastJunction;
-      }
-      else if (i < alarmSearchJunction)
-      {
-        // take whatever we took last time, look in address
-        if (alarmSearchAddress[ibyte] & ibit) a = 1;
-        else
+        uint8_t a = _wire->read_bit( );
+        uint8_t nota = _wire->read_bit( );
+        uint8_t ibyte = i / 8;
+        uint8_t ibit = 1 << (i & 7);
+
+        // I don't think this should happen, this means nothing responded, but maybe if
+        // something vanishes during the search it will come up.
+        if (a && nota) return false;
+
+        if (!a && !nota)
         {
-          // Only 0s count as pending junctions, we've already exhasuted the 0 side of 1s
-          a = 0;
-          done = 0;
-          lastJunction = i;
+            if (i == alarmSearchJunction)
+            {
+                // this is our time to decide differently, we went zero last time, go one.
+                a = 1;
+                alarmSearchJunction = lastJunction;
+            }
+            else if (i < alarmSearchJunction)
+            {
+                // take whatever we took last time, look in address
+                if (alarmSearchAddress[ibyte] & ibit) a = 1;
+                else
+                {
+                    // Only 0s count as pending junctions, we've already exhausted the 0 side of 1s
+                    a = 0;
+                    done = 0;
+                    lastJunction = i;
+                }
+            }
+            else
+            {
+                // we are blazing new tree, take the 0
+                a = 0;
+                alarmSearchJunction = i;
+                done = 0;
+            }
+            // OneWire search fix
+            // See: http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1238032295
         }
-      }
-      else
-      {
-        // we are blazing new tree, take the 0
-        a = 0;
-        alarmSearchJunction = i;
-        done = 0;
-      }
-      // OneWire search fix
-      // See: http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1238032295
+
+        if (a) alarmSearchAddress[ibyte] |= ibit;
+        else alarmSearchAddress[ibyte] &= ~ibit;
+
+        _wire->write_bit(a);
     }
 
-    if (a) alarmSearchAddress[ibyte] |= ibit;
-    else alarmSearchAddress[ibyte] &= ~ibit;
-
-    _wire->write_bit(a);
-  }
-
-  if (done) alarmSearchExhausted = 1;
-  for (i = 0; i < 8; i++) newAddr[i] = alarmSearchAddress[i];
-  return true;
+    if (done) alarmSearchExhausted = 1;
+    for (i = 0; i < 8; i++) newAddr[i] = alarmSearchAddress[i];
+    return true;
 }
 
-// returns true if device address has an alarm condition
-bool DallasTemperature::hasAlarm(uint8_t* deviceAddress)
+// returns true if device address might have an alarm condition
+// (only an alarm search can verify this)
+bool DallasTemperature::hasAlarm(const uint8_t* deviceAddress)
 {
-  ScratchPad scratchPad;
-  if (isConnected(deviceAddress, scratchPad))
-  {
-    float temp = calculateTemperature(deviceAddress, scratchPad);
+    ScratchPad scratchPad;
+    if (isConnected(deviceAddress, scratchPad))
+    {
+        char temp = calculateTemperature(deviceAddress, scratchPad) >> 7;
 
-    // check low alarm
-    if ((char)temp <= (char)scratchPad[LOW_ALARM_TEMP]) return true;
+        // check low alarm
+        if (temp <= (char)scratchPad[LOW_ALARM_TEMP]) return true;
 
-    // check high alarm
-    if ((char)temp >= (char)scratchPad[HIGH_ALARM_TEMP]) return true;
-  }
+        // check high alarm
+        if (temp >= (char)scratchPad[HIGH_ALARM_TEMP]) return true;
+    }
 
-  // no alarm
-  return false;
+    // no alarm
+    return false;
 }
 
 // returns true if any device is reporting an alarm condition on the bus
 bool DallasTemperature::hasAlarm(void)
 {
-  DeviceAddress deviceAddress;
-  resetAlarmSearch();
-  return alarmSearch(deviceAddress);
+    DeviceAddress deviceAddress;
+    resetAlarmSearch();
+    return alarmSearch(deviceAddress);
 }
 
 // runs the alarm handler for all devices returned by alarmSearch()
 void DallasTemperature::processAlarms(void)
 {
-  resetAlarmSearch();
-  DeviceAddress alarmAddr;
+    resetAlarmSearch();
+    DeviceAddress alarmAddr;
 
-  while (alarmSearch(alarmAddr))
-  {
-    if (validAddress(alarmAddr))
-      _AlarmHandler(alarmAddr);
-  }
+    while (alarmSearch(alarmAddr))
+    {
+        if (validAddress(alarmAddr))
+            _AlarmHandler(alarmAddr);
+    }
 }
 
 // sets the alarm handler
 void DallasTemperature::setAlarmHandler(AlarmHandler *handler)
 {
-  _AlarmHandler = handler;
+    _AlarmHandler = handler;
 }
 
 // The default alarm handler
-void DallasTemperature::defaultAlarmHandler(uint8_t* deviceAddress)
+void DallasTemperature::defaultAlarmHandler(const uint8_t* deviceAddress)
 {
 }
 
 #endif
 
-// Convert float celsius to fahrenheit
+// Convert float Celsius to Fahrenheit
 float DallasTemperature::toFahrenheit(float celsius)
 {
-  return (celsius * 1.8) + 32;
+    return (celsius * 1.8) + 32;
 }
 
-// Convert float fahrenheit to celsius
+// Convert float Fahrenheit to Celsius
 float DallasTemperature::toCelsius(float fahrenheit)
 {
-  return (fahrenheit - 32) / 1.8;
+    return (fahrenheit - 32) * 0.555555556;
+}
+
+// convert from raw to Celsius
+float DallasTemperature::rawToCelsius(int16_t raw)
+{
+    if (raw <= DEVICE_DISCONNECTED_RAW)
+        return DEVICE_DISCONNECTED_C;
+    // C = RAW/128
+    return (float)raw * 0.0078125;
+}
+
+// convert from raw to Fahrenheit
+float DallasTemperature::rawToFahrenheit(int16_t raw)
+{
+    if (raw <= DEVICE_DISCONNECTED_RAW)
+        return DEVICE_DISCONNECTED_F;
+    // C = RAW/128
+    // F = (C*1.8)+32 = (RAW/128*1.8)+32 = (RAW*0.0140625)+32
+    return ((float)raw * 0.0140625) + 32;
 }
 
 #if REQUIRESNEW
@@ -598,21 +740,21 @@ float DallasTemperature::toCelsius(float fahrenheit)
 // MnetCS - Allocates memory for DallasTemperature. Allows us to instance a new object
 void* DallasTemperature::operator new(unsigned int size) // Implicit NSS obj size
 {
-  void * p; // void pointer
-  p = malloc(size); // Allocate memory
-  memset((DallasTemperature*)p,0,size); // Initalise memory
+    void * p; // void pointer
+    p = malloc(size); // Allocate memory
+    memset((DallasTemperature*)p,0,size); // Initialise memory
 
-  //!!! CANT EXPLICITLY CALL CONSTRUCTOR - workaround by using an init() methodR - workaround by using an init() method
-  return (DallasTemperature*) p; // Cast blank region to NSS pointer
+    //!!! CANT EXPLICITLY CALL CONSTRUCTOR - workaround by using an init() methodR - workaround by using an init() method
+    return (DallasTemperature*) p; // Cast blank region to NSS pointer
 }
 
-// MnetCS 2009 -  Unallocates the memory used by this instance
+// MnetCS 2009 -  Free the memory used by this instance
 void DallasTemperature::operator delete(void* p)
 {
-  DallasTemperature* pNss =  (DallasTemperature*) p; // Cast to NSS pointer
-  pNss->~DallasTemperature(); // Destruct the object
+    DallasTemperature* pNss =  (DallasTemperature*) p; // Cast to NSS pointer
+    pNss->~DallasTemperature(); // Destruct the object
 
-  free(p); // Free the memory
+    free(p); // Free the memory
 }
 
 #endif

--- a/libraries/DallasTemperature/DallasTemperature.h
+++ b/libraries/DallasTemperature/DallasTemperature.h
@@ -1,6 +1,8 @@
 #ifndef DallasTemperature_h
 #define DallasTemperature_h
 
+#define DALLASTEMPLIBVERSION "3.7.2"
+
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation; either
@@ -20,9 +22,10 @@
 #include <OneWire.h>
 
 // Model IDs
-#define DS18S20MODEL 0x10
+#define DS18S20MODEL 0x10  // also DS1820
 #define DS18B20MODEL 0x28
 #define DS1822MODEL  0x22
+#define DS1825MODEL  0x3B
 
 // OneWire commands
 #define STARTCONVO      0x44  // Tells device to take a temperature reading and put it on the scratchpad
@@ -51,7 +54,9 @@
 #define TEMP_12_BIT 0x7F // 12 bit
 
 // Error Codes
-#define DEVICE_DISCONNECTED -127
+#define DEVICE_DISCONNECTED_C -127
+#define DEVICE_DISCONNECTED_F -196.6
+#define DEVICE_DISCONNECTED_RAW -7040
 
 typedef uint8_t DeviceAddress[8];
 
@@ -61,54 +66,71 @@ class DallasTemperature
 
   DallasTemperature(OneWire*);
 
-  // initalize bus
+  // initialise bus
   void begin(void);
 
   // returns the number of devices found on the bus
   uint8_t getDeviceCount(void);
   
   // returns true if address is valid
-  bool validAddress(uint8_t*);
+  bool validAddress(const uint8_t*);
 
   // finds an address at a given index on the bus 
-  bool getAddress(uint8_t*, const uint8_t);
+  bool getAddress(uint8_t*, uint8_t);
   
   // attempt to determine if the device at the given address is connected to the bus
-  bool isConnected(uint8_t*);
+  bool isConnected(const uint8_t*);
 
   // attempt to determine if the device at the given address is connected to the bus
   // also allows for updating the read scratchpad
-  bool isConnected(uint8_t*, uint8_t*);
+  bool isConnected(const uint8_t*, uint8_t*);
 
   // read device's scratchpad
-  void readScratchPad(uint8_t*, uint8_t*);
+  void readScratchPad(const uint8_t*, uint8_t*);
 
   // write device's scratchpad
-  void writeScratchPad(uint8_t*, const uint8_t*);
+  void writeScratchPad(const uint8_t*, const uint8_t*);
 
   // read device's power requirements
-  bool readPowerSupply(uint8_t*);
+  bool readPowerSupply(const uint8_t*);
 
-  // returns the current resolution, 9-12
-  uint8_t getResolution(uint8_t*);
+  // get global resolution
+  uint8_t getResolution();
+  
+  // set global resolution to 9, 10, 11, or 12 bits
+  void setResolution(uint8_t);
+
+  // returns the device resolution: 9, 10, 11, or 12 bits
+  uint8_t getResolution(const uint8_t*);
 
   // set resolution of a device to 9, 10, 11, or 12 bits
-  void setResolution(uint8_t*, uint8_t);
-
-  // sends command for all devices on the bus to perform a temperature conversion
+  bool setResolution(const uint8_t*, uint8_t);
+  
+  // sets/gets the waitForConversion flag
+  void setWaitForConversion(bool);
+  bool getWaitForConversion(void);
+  
+  // sets/gets the checkForConversion flag
+  void setCheckForConversion(bool);
+  bool getCheckForConversion(void);
+  
+  // sends command for all devices on the bus to perform a temperature conversion 
   void requestTemperatures(void);
    
   // sends command for one device to perform a temperature conversion by address
-  void requestTemperaturesByAddress(uint8_t*);
+  bool requestTemperaturesByAddress(const uint8_t*);
 
   // sends command for one device to perform a temperature conversion by index
-  void requestTemperaturesByIndex(uint8_t);
+  bool requestTemperaturesByIndex(uint8_t);
+
+  // returns temperature raw value (12 bit integer of 1/16 degrees C)
+  int16_t getTemp(const uint8_t*);
 
   // returns temperature in degrees C
-  float getTempC(uint8_t*);
+  float getTempC(const uint8_t*);
 
   // returns temperature in degrees F
-  float getTempF(uint8_t*);
+  float getTempF(const uint8_t*);
 
   // Get temperature for device index (slow)
   float getTempCByIndex(uint8_t);
@@ -118,26 +140,28 @@ class DallasTemperature
   
   // returns true if the bus requires parasite power
   bool isParasitePowerMode(void);
+  
+  bool isConversionAvailable(const uint8_t*);
 
   #if REQUIRESALARMS
   
-  typedef void AlarmHandler(uint8_t*);
+  typedef void AlarmHandler(const uint8_t*);
 
   // sets the high alarm temperature for a device
   // accepts a char.  valid range is -55C - 125C
-  void setHighAlarmTemp(uint8_t*, const char);
+  void setHighAlarmTemp(const uint8_t*, char);
 
   // sets the low alarm temperature for a device
   // accepts a char.  valid range is -55C - 125C
-  void setLowAlarmTemp(uint8_t*, const char);
+  void setLowAlarmTemp(const uint8_t*, char);
 
   // returns a signed char with the current high alarm temperature for a device
   // in the range -55C - 125C
-  char getHighAlarmTemp(uint8_t*);
+  char getHighAlarmTemp(const uint8_t*);
 
   // returns a signed char with the current low alarm temperature for a device
   // in the range -55C - 125C
-  char getLowAlarmTemp(uint8_t*);
+  char getLowAlarmTemp(const uint8_t*);
   
   // resets internal variables used for the alarm search
   void resetAlarmSearch(void);
@@ -146,7 +170,7 @@ class DallasTemperature
   bool alarmSearch(uint8_t*);
 
   // returns true if ia specific device has an alarm
-  bool hasAlarm(uint8_t*);
+  bool hasAlarm(const uint8_t*);
 
   // returns true if any device is reporting an alarm on the bus
   bool hasAlarm(void);
@@ -155,22 +179,28 @@ class DallasTemperature
   void processAlarms(void);
   
   // sets the alarm handler
-  void setAlarmHandler(AlarmHandler *);
+  void setAlarmHandler(const AlarmHandler *);
   
   // The default alarm handler
-  static void defaultAlarmHandler(uint8_t*);
+  static void defaultAlarmHandler(const uint8_t*);
 
   #endif
 
-  // convert from celcius to farenheit
-  static float toFahrenheit(const float);
+  // convert from Celsius to Fahrenheit
+  static float toFahrenheit(float);
 
-  // convert from farenheit to celsius
-  static float toCelsius(const float);
+  // convert from Fahrenheit to Celsius
+  static float toCelsius(float);
+
+  // convert from raw to Celsius
+  static float rawToCelsius(int16_t);
+
+  // convert from raw to Fahrenheit
+  static float rawToFahrenheit(int16_t);
 
   #if REQUIRESNEW
 
-  // initalize memory area
+  // initialize memory area
   void* operator new (unsigned int);
 
   // delete memory reference
@@ -186,16 +216,26 @@ class DallasTemperature
 
   // used to determine the delay amount needed to allow for the
   // temperature conversion to take place
-  int conversionDelay;
-
+  uint8_t bitResolution;
+  
+  // used to requestTemperature with or without delay
+  bool waitForConversion;
+  
+  // used to requestTemperature to dynamically check if a conversion is complete
+  bool checkForConversion;
+  
   // count of devices on the bus
   uint8_t devices;
   
   // Take a pointer to one wire instance
   OneWire* _wire;
 
-  // reads scratchpad and returns the temperature in degrees C
-  float calculateTemperature(uint8_t*, uint8_t*);
+  // reads scratchpad and returns the raw temperature
+  int16_t calculateTemperature(const uint8_t*, uint8_t*);
+  
+  int16_t millisToWaitForConversion(uint8_t);
+
+  void	blockTillConversionComplete(uint8_t, const uint8_t*);
   
   #if REQUIRESALARMS
 

--- a/libraries/DallasTemperature/DallasTemperature.h
+++ b/libraries/DallasTemperature/DallasTemperature.h
@@ -116,7 +116,10 @@ class DallasTemperature
   
   // sends command for all devices on the bus to perform a temperature conversion 
   void requestTemperatures(void);
-   
+
+  // returns time to wait for a temperature conversion based on given resolution 
+  int16_t millisToWaitForConversion(uint8_t);
+
   // sends command for one device to perform a temperature conversion by address
   bool requestTemperaturesByAddress(const uint8_t*);
 
@@ -233,8 +236,6 @@ class DallasTemperature
   // reads scratchpad and returns the raw temperature
   int16_t calculateTemperature(const uint8_t*, uint8_t*);
   
-  int16_t millisToWaitForConversion(uint8_t);
-
   void	blockTillConversionComplete(uint8_t, const uint8_t*);
   
   #if REQUIRESALARMS

--- a/libraries/DallasTemperature/README.md
+++ b/libraries/DallasTemperature/README.md
@@ -4,10 +4,14 @@ Arduino Library for Dallas Temperature ICs
 Usage
 -----
 
-This library supports the following devices:
-    DS18B20
-    DS18S20 - Please note there appears to be an issue with this series.
-    DS1822
+This library supports the following devices :
+
+
+* DS18B20
+* DS18S20 - Please note there appears to be an issue with this series.
+* DS1822
+* DS1820
+
 
 You will need a pull-up resistor of about 5 KOhm between the 1-Wire data line
 and your 5V power. If you are using the DS18B20, ground pins 1 and 3. The
@@ -15,7 +19,18 @@ centre pin is the data line '1-wire'.
 
 We have included a "REQUIRESNEW" and "REQUIRESALARMS" definition. If you 
 want to slim down the code feel free to use either of these by including
-#define REQUIRESNEW or #define REQUIRESALARMS a the top of DallasTemperature.h
+
+
+
+	#define REQUIRESNEW 
+
+or 
+
+	#define REQUIRESALARMS
+
+
+at the top of DallasTemperature.h
+
 
 Credits
 -------
@@ -26,6 +41,8 @@ Miles Burton <miles@mnetcs.com> originally developed this library.
 Tim Newsome <nuisance@casualhacker.net> added support for multiple sensors on
 the same bus.
 Guil Barros [gfbarros@bappos.com] added getTempByAddress (v3.5)
+Rob Tillaart [rob.tillaart@gmail.com] added async modus (v3.7.0)
+
 
 Website
 -------

--- a/libraries/DallasTemperature/change.txt
+++ b/libraries/DallasTemperature/change.txt
@@ -1,0 +1,85 @@
+
+This file contains the change history of the Dallas Temperature Control Library.
+
+VERSION 3.7.2 BETA
+===================
+DATE: 6 DEC  2011
+
+- Jordan Hochenbaum [jhochenbaum@gmail.com] updated library for compatibility with Arduino 1.0.
+
+VERSION 3.7.0 BETA
+===================
+DATE: 11 JAN  2011
+
+- Rob Tillaart [rob.tillaart@gmail.com] added async modus (v3.7.0)
+  The library is backwards compatible with version 3.6.0
+
+  MAJOR: async modus
+  ------------------
+- Added - private bool waitForConversion. 
+This boolean is default set to true in the Constructor to keep the library backwards compatible. If this flag is true calls to requestTemperatures(), requestTemperaturesByAddress() et al, will be blocking with the appropiate time specified (in datasheet) for the resolution used. If the flag is set to false, requestTemperatures() et al, will return immediately after the conversion command is send over the 1-wire interface. The programmer is responsible to wait long enough before reading the temperature values. This enables the application to do other things while waiting for a new reading, like calculations, update LCD, read/write other IO lines etc. See examples.
+
+- Added - void setWaitForConversion(bool); 
+To set the flag to true or false, depending on the modus needed.
+
+- Added - bool getWaitForConversion(void); 
+To get the current value of the flag.
+
+- Changed - void requestTemperatures(void);
+Added a test (false == waitForConversion) to return immediately after the conversion command instead of waiting until the conversion is ready.
+ 
+- Changed - bool requestTemperaturesByAddress(uint8_t*); 
+Added a test (false == waitForConversion) to return immediately after the conversion command instead of waiting until the conversion is ready.
+
+
+  MINOR version number
+  --------------------
+- Added - #define DALLASTEMPLIBVERSION "3.7.0" 
+To indicate the version number in .h file 
+  
+  
+  MINOR internal var bitResolution
+  ----------------------------
+- Changed - private int conversionDelay - is renamed to - private int bitResolution
+As this variable holds the resolution. The delay for the conversion is derived from it.
+
+- Changed - uint8_t getResolution(uint8_t* deviceAddress);
+If the device is not connected, it returns 0, otherwise it returns the resolution of the device.
+
+- Changed - bool setResolution(uint8_t* deviceAddress, uint8_t newResolution);
+If the device is not connected, it returns FALSE (fail), otherwise it returns TRUE (succes).
+
+- Added - uint8_t getResolution();
+Returns bitResolution.
+
+- Added - void setResolution(uint8_t newResolution)
+Sets the internal variable bitResolution, and all devices to this value
+
+
+  MINOR check connected state
+  ----------------------------
+- Changed - bool requestTemperaturesByIndex(deviceIndex) 
+Changed return type from void to bool. The function returns false if the device identified with [deviceIndex] is not found on the bus and true otherwise.
+
+- Changed - bool requestTemperaturesByAddress(deviceAddress)
+Changed return type from void to bool. The function returns false if the device identified with [deviceAddress] is not found on the bus and true otherwise.
+Added code to handle the DS18S20 which has a 9 bit resolution separately.
+Changed code so the blocking delay matches the bitResolution set in the device with deviceAddress.
+
+- Changed - bool requestTemperaturesByIndex(uint8_t deviceIndex)
+Changed return type from void to bool. The function returns false if the device identified with [deviceIndex] is not found on the bus and true otherwise.
+
+
+
+VERSION 3.6.0
+==============
+DATE: 2010-10-10
+
+- no detailed change history known except:
+
+- The OneWire code has been derived from
+http://www.arduino.cc/playground/Learning/OneWire.
+- Miles Burton <miles@mnetcs.com> originally developed this library.
+- Tim Newsome <nuisance@casualhacker.net> added support for multiple sensors on
+the same bus.
+- Guil Barros [gfbarros@bappos.com] added getTempByAddress (v3.5)

--- a/libraries/DallasTemperature/examples/Alarm/Alarm.pde
+++ b/libraries/DallasTemperature/examples/Alarm/Alarm.pde
@@ -2,7 +2,7 @@
 #include <DallasTemperature.h>
 
 // Data wire is plugged into port 2 on the Arduino
-#define ONE_WIRE_BUS 3
+#define ONE_WIRE_BUS 2
 
 // Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
 OneWire oneWire(ONE_WIRE_BUS);

--- a/libraries/DallasTemperature/examples/AlarmHandler/AlarmHandler.pde
+++ b/libraries/DallasTemperature/examples/AlarmHandler/AlarmHandler.pde
@@ -2,8 +2,7 @@
 #include <DallasTemperature.h>
 
 // Data wire is plugged into port 2 on the Arduino
-#define ONE_WIRE_BUS 3
-#define TEMPERATURE_PRECISION 9
+#define ONE_WIRE_BUS 2
 
 // Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
 OneWire oneWire(ONE_WIRE_BUS);

--- a/libraries/DallasTemperature/examples/Multiple/Multiple.pde
+++ b/libraries/DallasTemperature/examples/Multiple/Multiple.pde
@@ -2,7 +2,7 @@
 #include <DallasTemperature.h>
 
 // Data wire is plugged into port 2 on the Arduino
-#define ONE_WIRE_BUS 3
+#define ONE_WIRE_BUS 2
 #define TEMPERATURE_PRECISION 9
 
 // Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
@@ -74,8 +74,8 @@ void setup(void)
   Serial.println();
 
   // set the resolution to 9 bit
-  sensors.setResolution(insideThermometer, 9);
-  sensors.setResolution(outsideThermometer, 9);
+  sensors.setResolution(insideThermometer, TEMPERATURE_PRECISION);
+  sensors.setResolution(outsideThermometer, TEMPERATURE_PRECISION);
 
   Serial.print("Device 0 Resolution: ");
   Serial.print(sensors.getResolution(insideThermometer), DEC); 

--- a/libraries/DallasTemperature/examples/Single/Single.pde
+++ b/libraries/DallasTemperature/examples/Single/Single.pde
@@ -2,7 +2,7 @@
 #include <DallasTemperature.h>
 
 // Data wire is plugged into port 2 on the Arduino
-#define ONE_WIRE_BUS 3
+#define ONE_WIRE_BUS 2
 
 // Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
 OneWire oneWire(ONE_WIRE_BUS);

--- a/libraries/DallasTemperature/examples/Tester/Tester.pde
+++ b/libraries/DallasTemperature/examples/Tester/Tester.pde
@@ -2,7 +2,7 @@
 #include <DallasTemperature.h>
 
 // Data wire is plugged into port 2 on the Arduino
-#define ONE_WIRE_BUS 3
+#define ONE_WIRE_BUS 2
 #define TEMPERATURE_PRECISION 9
 
 // Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
@@ -52,9 +52,9 @@ void setup(void)
 		Serial.println();
 		
 		Serial.print("Setting resolution to ");
-		Serial.println(TEMPERATURE_PRECISION,DEC);
+		Serial.println(TEMPERATURE_PRECISION, DEC);
 		
-		// set the resolution to 9 bit (Each Dallas/Maxim device is capable of several different resolutions)
+		// set the resolution to TEMPERATURE_PRECISION bit (Each Dallas/Maxim device is capable of several different resolutions)
 		sensors.setResolution(tempDeviceAddress, TEMPERATURE_PRECISION);
 		
 		 Serial.print("Resolution actually set to: ");

--- a/libraries/DallasTemperature/examples/WaitForConversion/WaitForConversion.pde
+++ b/libraries/DallasTemperature/examples/WaitForConversion/WaitForConversion.pde
@@ -1,0 +1,66 @@
+#include <OneWire.h>
+#include <DallasTemperature.h>
+
+// Data wire is plugged into port 2 on the Arduino
+#define ONE_WIRE_BUS 2
+
+// Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
+OneWire oneWire(ONE_WIRE_BUS);
+
+// Pass our oneWire reference to Dallas Temperature. 
+DallasTemperature sensors(&oneWire);
+
+void setup(void)
+{
+  // start serial port
+  Serial.begin(115200);
+  Serial.println("Dallas Temperature Control Library - Async Demo");
+  Serial.println("\nDemo shows the difference in length of the call\n\n");
+
+  // Start up the library
+  sensors.begin();
+}
+
+void loop(void)
+{ 
+  // Request temperature conversion (traditional)
+  Serial.println("Before blocking requestForConversion");
+  unsigned long start = millis();    
+
+  sensors.requestTemperatures();
+
+  unsigned long stop = millis();
+  Serial.println("After blocking requestForConversion");
+  Serial.print("Time used: ");
+  Serial.println(stop - start);
+  
+  // get temperature
+  Serial.print("Temperature: ");
+  Serial.println(sensors.getTempCByIndex(0));  
+  Serial.println("\n");
+  
+  // Request temperature conversion - non-blocking / async
+  Serial.println("Before NON-blocking/async requestForConversion");
+  start = millis();       
+  sensors.setWaitForConversion(false);  // makes it async
+  sensors.requestTemperatures();
+  sensors.setWaitForConversion(true);
+  stop = millis();
+  Serial.println("After NON-blocking/async requestForConversion");
+  Serial.print("Time used: ");
+  Serial.println(stop - start); 
+  
+  
+  // 9 bit resolution by default 
+  // Note the programmer is responsible for the right delay
+  // we could do something usefull here instead of the delay
+  int resolution = 9;
+  delay(750/ (1 << (12-resolution)));
+  
+  // get temperature
+  Serial.print("Temperature: ");
+  Serial.println(sensors.getTempCByIndex(0));  
+  Serial.println("\n\n\n\n");  
+  
+  delay(5000);
+}

--- a/libraries/DallasTemperature/examples/WaitForConversion2/WaitForConversion2.pde
+++ b/libraries/DallasTemperature/examples/WaitForConversion2/WaitForConversion2.pde
@@ -1,0 +1,80 @@
+//
+// Sample of using Async reading of Dallas Temperature Sensors
+// 
+#include <OneWire.h>
+#include <DallasTemperature.h>
+
+// Data wire is plugged into port 2 on the Arduino
+#define ONE_WIRE_BUS 2
+
+// Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
+OneWire oneWire(ONE_WIRE_BUS);
+
+// Pass our oneWire reference to Dallas Temperature. 
+DallasTemperature sensors(&oneWire);
+
+DeviceAddress tempDeviceAddress;
+
+int  resolution = 12;
+unsigned long lastTempRequest = 0;
+int  delayInMillis = 0;
+float temperature = 0.0;
+int  idle = 0;
+//
+// SETUP
+//
+void setup(void)
+{
+  Serial.begin(115200);
+  Serial.println("Dallas Temperature Control Library - Async Demo");
+  Serial.print("Library Version: ");
+  Serial.println(DALLASTEMPLIBVERSION);
+  Serial.println("\n");
+
+  sensors.begin();
+  sensors.getAddress(tempDeviceAddress, 0);
+  sensors.setResolution(tempDeviceAddress, resolution);
+  
+  sensors.setWaitForConversion(false);
+  sensors.requestTemperatures();
+  delayInMillis = 750 / (1 << (12 - resolution)); 
+  lastTempRequest = millis(); 
+  
+  pinMode(13, OUTPUT); 
+}
+
+void loop(void)
+{ 
+  
+  if (millis() - lastTempRequest >= delayInMillis) // waited long enough??
+  {
+    digitalWrite(13, LOW);
+    Serial.print(" Temperature: ");
+    temperature = sensors.getTempCByIndex(0);
+    Serial.println(temperature, resolution - 8); 
+    Serial.print("  Resolution: ");
+    Serial.println(resolution); 
+    Serial.print("Idle counter: ");
+    Serial.println(idle);     
+    Serial.println(); 
+    
+    idle = 0; 
+        
+    // immediately after fetching the temperature we request a new sample 
+	// in the async modus
+    // for the demo we let the resolution change to show differences
+    resolution++;
+    if (resolution > 12) resolution = 9;
+    
+    sensors.setResolution(tempDeviceAddress, resolution);
+    sensors.requestTemperatures(); 
+    delayInMillis = 750 / (1 << (12 - resolution));
+    lastTempRequest = millis(); 
+  }
+  
+  digitalWrite(13, HIGH);
+  // we can do usefull things here 
+  // for the demo we just count the idle time in millis
+  delay(1);
+  idle++;
+}

--- a/libraries/DallasTemperature/keywords.txt
+++ b/libraries/DallasTemperature/keywords.txt
@@ -7,8 +7,8 @@
 #######################################
 DallasTemperature	KEYWORD1
 OneWire	KEYWORD1
-AlarmHandler KEYWORD1
-DeviceAddress KEYWORD1
+AlarmHandler	KEYWORD1
+DeviceAddress	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -20,12 +20,14 @@ getTempC	KEYWORD2
 toFahrenheit	KEYWORD2
 getTempF	KEYWORD2
 getTempCByIndex 	KEYWORD2
-getTempFByIndex	KEYWORD2
+getTempFByIndex		KEYWORD2
+setWaitForConversion	KEYWORD2
+getWaitForConversion	KEYWORD2
 requestTemperatures	KEYWORD2
-requestTemperaturesByAddress KEYWORD2
-requestTemperaturesByIndex KEYWORD2
+requestTemperaturesByAddress	KEYWORD2
+requestTemperaturesByIndex	KEYWORD2
 isParasitePowerMode	KEYWORD2
-begin KEYWORD2
+begin	KEYWORD2
 getDeviceCount	KEYWORD2
 getAddress	KEYWORD2
 validAddress	KEYWORD2
@@ -45,6 +47,7 @@ processAlarmss	KEYWORD2
 setAlarmHandlers	KEYWORD2
 defaultAlarmHandler	KEYWORD2
 calculateTemperature	KEYWORD2
+millisToWaitForConversion	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/DallasTemperature/library.json
+++ b/libraries/DallasTemperature/library.json
@@ -1,0 +1,39 @@
+{
+  "name": "DallasTemperature",
+  "keywords": "onewire, 1-wire, bus, sensor, temperature",
+  "description": "Arduino Library for Dallas Temperature ICs (DS18B20, DS18S20, DS1822, DS1820)",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/milesburton/Arduino-Temperature-Control-Library.git"
+  },
+  "authors": 
+  [
+    {
+      "name": "Miles Burton",
+      "email": "miles@mnetcs.com",
+      "url": "http://www.milesburton.com",
+      "maintainer": true
+    },
+    {
+      "name": "Tim Newsome",
+      "email": "nuisance@casualhacker.net"
+    },
+    {
+      "name": "Guil Barros",
+      "email": "gfbarros@bappos.com"
+    },
+    {
+      "name": "Rob Tillaart",
+      "email": "rob.tillaart@gmail.com"
+    }
+  ],
+  "dependencies":
+  {
+    "name": "OneWire",
+    "authors": "Paul Stoffregen",
+    "frameworks": "arduino"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/libraries/MySensors/examples/DallasTemperatureSensor/DallasTemperatureSensor.ino
+++ b/libraries/MySensors/examples/DallasTemperatureSensor/DallasTemperatureSensor.ino
@@ -21,6 +21,8 @@ void setup()
 { 
   // Startup OneWire 
   sensors.begin();
+  // requestTemperatures() will not block current thread
+  sensors.setWaitForConversion(false);
 
   // Startup and initialize MySensors library. Set callback for incoming messages. 
   gw.begin(); 
@@ -44,7 +46,12 @@ void loop()
   gw.process(); 
 
   // Fetch temperatures from Dallas sensors
-  sensors.requestTemperatures(); 
+  sensors.requestTemperatures();
+
+  // query conversion time and sleep until conversion completed
+  int16_t conversionTime = sensors.millisToWaitForConversion(sensors.getResolution());
+  // sleep() call can be replaced by wait() call if node need to process incoming messages (or if node is repeater)
+  gw.sleep(conversionTime);
 
   // Read temperatures and send them to controller 
   for (int i=0; i<numSensors && i<MAX_ATTACHED_DS18B20; i++) {
@@ -62,6 +69,3 @@ void loop()
   }
   gw.sleep(SLEEP_TIME);
 }
-
-
-

--- a/libraries/OneWire/OneWire.cpp
+++ b/libraries/OneWire/OneWire.cpp
@@ -4,6 +4,24 @@ Copyright (c) 2007, Jim Studt  (original old version - many contributors since)
 The latest version of this library may be found at:
   http://www.pjrc.com/teensy/td_libs_OneWire.html
 
+OneWire has been maintained by Paul Stoffregen (paul@pjrc.com) since
+January 2010.  At the time, it was in need of many bug fixes, but had
+been abandoned the original author (Jim Studt).  None of the known
+contributors were interested in maintaining OneWire.  Paul typically
+works on OneWire every 6 to 12 months.  Patches usually wait that
+long.  If anyone is interested in more actively maintaining OneWire,
+please contact Paul.
+
+Version 2.2:
+  Teensy 3.0 compatibility, Paul Stoffregen, paul@pjrc.com
+  Arduino Due compatibility, http://arduino.cc/forum/index.php?topic=141030
+  Fix DS18B20 example negative temperature
+  Fix DS18B20 example's low res modes, Ken Butcher
+  Improve reset timing, Mark Tillotson
+  Add const qualifiers, Bertrik Sikken
+  Add initial value input to crc16, Bertrik Sikken
+  Add target_search() function, Scott Roberts
+
 Version 2.1:
   Arduino 1.0 compatibility, Paul Stoffregen
   Improve temperature example, Paul Stoffregen
@@ -136,13 +154,13 @@ uint8_t OneWire::reset(void)
 	DIRECT_WRITE_LOW(reg, mask);
 	DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
 	interrupts();
-	delayMicroseconds(500);
+	delayMicroseconds(480);
 	noInterrupts();
 	DIRECT_MODE_INPUT(reg, mask);	// allow it to float
-	delayMicroseconds(80);
+	delayMicroseconds(70);
 	r = !DIRECT_READ(reg, mask);
 	interrupts();
-	delayMicroseconds(420);
+	delayMicroseconds(410);
 	return r;
 }
 
@@ -249,13 +267,13 @@ void OneWire::read_bytes(uint8_t *buf, uint16_t count) {
 //
 // Do a ROM select
 //
-void OneWire::select( uint8_t rom[8])
+void OneWire::select(const uint8_t rom[8])
 {
-    int i;
+    uint8_t i;
 
     write(0x55);           // Choose ROM
 
-    for( i = 0; i < 8; i++) write(rom[i]);
+    for (i = 0; i < 8; i++) write(rom[i]);
 }
 
 //
@@ -280,17 +298,30 @@ void OneWire::depower()
 // You do not need to do it for the first search, though you could.
 //
 void OneWire::reset_search()
-  {
+{
   // reset the search state
   LastDiscrepancy = 0;
   LastDeviceFlag = FALSE;
   LastFamilyDiscrepancy = 0;
-  for(int i = 7; ; i--)
-    {
+  for(int i = 7; ; i--) {
     ROM_NO[i] = 0;
     if ( i == 0) break;
-    }
   }
+}
+
+// Setup the search to find the device type 'family_code' on the next call
+// to search(*newAddr) if it is present.
+//
+void OneWire::target_search(uint8_t family_code)
+{
+   // set the search state to find SearchFamily type devices
+   ROM_NO[0] = family_code;
+   for (uint8_t i = 1; i < 8; i++)
+      ROM_NO[i] = 0;
+   LastDiscrepancy = 64;
+   LastFamilyDiscrepancy = 0;
+   LastDeviceFlag = FALSE;
+}
 
 //
 // Perform a search. If this function returns a '1' then it has
@@ -461,7 +492,7 @@ static const uint8_t PROGMEM dscrc_table[] = {
 // compared to all those delayMicrosecond() calls.  But I got
 // confused, so I use this table from the examples.)
 //
-uint8_t OneWire::crc8( uint8_t *addr, uint8_t len)
+uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
 {
 	uint8_t crc = 0;
 
@@ -475,7 +506,7 @@ uint8_t OneWire::crc8( uint8_t *addr, uint8_t len)
 // Compute a Dallas Semiconductor 8 bit CRC directly.
 // this is much slower, but much smaller, than the lookup table.
 //
-uint8_t OneWire::crc8( uint8_t *addr, uint8_t len)
+uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
 {
 	uint8_t crc = 0;
 	
@@ -493,23 +524,22 @@ uint8_t OneWire::crc8( uint8_t *addr, uint8_t len)
 #endif
 
 #if ONEWIRE_CRC16
-bool OneWire::check_crc16(uint8_t* input, uint16_t len, uint8_t* inverted_crc)
+bool OneWire::check_crc16(const uint8_t* input, uint16_t len, const uint8_t* inverted_crc, uint16_t crc)
 {
-    uint16_t crc = ~crc16(input, len);
+    crc = ~crc16(input, len, crc);
     return (crc & 0xFF) == inverted_crc[0] && (crc >> 8) == inverted_crc[1];
 }
 
-uint16_t OneWire::crc16(uint8_t* input, uint16_t len)
+uint16_t OneWire::crc16(const uint8_t* input, uint16_t len, uint16_t crc)
 {
     static const uint8_t oddparity[16] =
         { 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0 };
-    uint16_t crc = 0;    // Starting seed is zero.
 
     for (uint16_t i = 0 ; i < len ; i++) {
       // Even though we're just copying a byte from the input,
       // we'll be doing 16-bit computation with it.
       uint16_t cdata = input[i];
-      cdata = (cdata ^ (crc & 0xff)) & 0xff;
+      cdata = (cdata ^ crc) & 0xff;
       crc >>= 8;
 
       if (oddparity[cdata & 0x0F] ^ oddparity[cdata >> 4])

--- a/libraries/OneWire/examples/DS18x20_Temperature/DS18x20_Temperature.pde
+++ b/libraries/OneWire/examples/DS18x20_Temperature/DS18x20_Temperature.pde
@@ -7,7 +7,7 @@
 // The DallasTemperature library can do all this work for you!
 // http://milesburton.com/Dallas_Temperature_Control_Library
 
-OneWire  ds(10);  // on pin 10
+OneWire  ds(10);  // on pin 10 (a 4.7K resistor is necessary)
 
 void setup(void) {
   Serial.begin(9600);
@@ -62,7 +62,7 @@ void loop(void) {
 
   ds.reset();
   ds.select(addr);
-  ds.write(0x44,1);         // start conversion, with parasite power on at the end
+  ds.write(0x44, 1);        // start conversion, with parasite power on at the end
   
   delay(1000);     // maybe 750ms is enough, maybe not
   // we might do a ds.depower() here, but the reset will take care of it.
@@ -72,7 +72,7 @@ void loop(void) {
   ds.write(0xBE);         // Read Scratchpad
 
   Serial.print("  Data = ");
-  Serial.print(present,HEX);
+  Serial.print(present, HEX);
   Serial.print(" ");
   for ( i = 0; i < 9; i++) {           // we need 9 bytes
     data[i] = ds.read();
@@ -83,21 +83,24 @@ void loop(void) {
   Serial.print(OneWire::crc8(data, 8), HEX);
   Serial.println();
 
-  // convert the data to actual temperature
-
-  unsigned int raw = (data[1] << 8) | data[0];
+  // Convert the data to actual temperature
+  // because the result is a 16 bit signed integer, it should
+  // be stored to an "int16_t" type, which is always 16 bits
+  // even when compiled on a 32 bit processor.
+  int16_t raw = (data[1] << 8) | data[0];
   if (type_s) {
     raw = raw << 3; // 9 bit resolution default
     if (data[7] == 0x10) {
-      // count remain gives full 12 bit resolution
+      // "count remain" gives full 12 bit resolution
       raw = (raw & 0xFFF0) + 12 - data[6];
     }
   } else {
     byte cfg = (data[4] & 0x60);
-    if (cfg == 0x00) raw = raw << 3;  // 9 bit resolution, 93.75 ms
-    else if (cfg == 0x20) raw = raw << 2; // 10 bit res, 187.5 ms
-    else if (cfg == 0x40) raw = raw << 1; // 11 bit res, 375 ms
-    // default is 12 bit resolution, 750 ms conversion time
+    // at lower res, the low bits are undefined, so let's zero them
+    if (cfg == 0x00) raw = raw & ~7;  // 9 bit resolution, 93.75 ms
+    else if (cfg == 0x20) raw = raw & ~3; // 10 bit res, 187.5 ms
+    else if (cfg == 0x40) raw = raw & ~1; // 11 bit res, 375 ms
+    //// default is 12 bit resolution, 750 ms conversion time
   }
   celsius = (float)raw / 16.0;
   fahrenheit = celsius * 1.8 + 32.0;


### PR DESCRIPTION
Updated DallasTemperature and OneWire libraries for non-blocking `requestTemperatures()` call. This allows deep sleep or process incoming messages during temperature conversion (up to 750 ms).