### PR TITLE
Changed the extended_fuses from 0xFE to 0x06 (set unused bits 3-7 to …

### DIFF
--- a/hardware/MySensors/avr/boards.txt
+++ b/hardware/MySensors/avr/boards.txt
@@ -16,7 +16,7 @@ MysensorsMicro.bootloader.unlock_bits=0x3F
 MysensorsMicro.bootloader.lock_bits=0x0F
 MysensorsMicro.bootloader.low_fuses=0xE2
 MysensorsMicro.bootloader.high_fuses=0xD2
-MysensorsMicro.bootloader.extended_fuses=0xFE
+MysensorsMicro.bootloader.extended_fuses=0x06
 MysensorsMicro.bootloader.file=DualOptiboot/optiboot_atmega328_pro_8MHz.hex
 
 MysensorsMicro.build.board=AVR_MICRO8

--- a/libraries/MySensors/MyConfig.h
+++ b/libraries/MySensors/MyConfig.h
@@ -58,11 +58,11 @@
 // default LEDs blinking period in milliseconds
 #define DEFAULT_LED_BLINK_PERIOD 300
 // The RX LED default pin
-#define DEFAULT_RX_LED_PIN 8
+#define DEFAULT_RX_LED_PIN 6
 // The TX LED default pin
-#define DEFAULT_TX_LED_PIN 9
+#define DEFAULT_TX_LED_PIN 5
 // The Error LED default pin
-#define DEFAULT_ERR_LED_PIN 7
+#define DEFAULT_ERR_LED_PIN 4
 
 
 /**********************************

--- a/libraries/MySensors/MySensor.cpp
+++ b/libraries/MySensors/MySensor.cpp
@@ -110,33 +110,33 @@ void MySensor::handleLedsBlinking() {
 	// do the actual blinking
 	if(countRx && countRx != 255) {
 		// switch led on
-		digitalWrite(pinRx, LOW);
+		digitalWrite(pinRx, HIGH);
 	}
 	else if(!countRx) {
 		// switching off
-		digitalWrite(pinRx, HIGH);
+		digitalWrite(pinRx, LOW);
 	}
 	if(countRx != 255)
 		--countRx;
 
 	if(countTx && countTx != 255) {
 		// switch led on
-		digitalWrite(pinTx, LOW);
+		digitalWrite(pinTx, HIGH);
 	}
 	else if(!countTx) {
 		// switching off
-		digitalWrite(pinTx, HIGH);
+		digitalWrite(pinTx, LOW);
 	}
 	if(countTx != 255)
 		--countTx;
 
 	if(countErr && countErr != 255) {
 		// switch led on
-		digitalWrite(pinEr, LOW);
+		digitalWrite(pinEr, HIGH);
 	}
 	else if(!countErr) {
 		// switching off
-		digitalWrite(pinEr, HIGH);
+		digitalWrite(pinEr, LOW);
 	}
 	if(countErr != 255)
 		--countErr;
@@ -182,9 +182,9 @@ void MySensor::begin(void (*_msgCallback)(const MyMessage &), uint8_t _nodeId, b
 	pinMode(pinEr, OUTPUT);
 
 	// Set initial state of leds
-	digitalWrite(pinRx, HIGH);
-	digitalWrite(pinTx, HIGH);
-	digitalWrite(pinEr, HIGH);
+	digitalWrite(pinRx, LOW);
+	digitalWrite(pinTx, LOW);
+	digitalWrite(pinEr, LOW);
 
 	// initialize counters
 	countRx = 0;


### PR DESCRIPTION
Reviewed this change with @tbowmo in Hangouts and he agreed with the change...

>Thomas, do you mind if I create a pull request to change the extended_fuses from 0xFE to 0x06?  The upper bits are inaccessible by certain programmers and not writable anyway so this would create broader compatibility.  I always have to change it when I want to burn a bootloader with the ATMEL Dragon or USB Tiny ISP.
In boards.txt

>>Thomas Bowman Mørch
Be my guest Bruce
