### PR TITLE
arduino target updates

### DIFF
--- a/hardware/MySensors/avr/boards.txt
+++ b/hardware/MySensors/avr/boards.txt
@@ -30,28 +30,3 @@ MysensorsMicro.menu.cpu.8Mhz.build.f_cpu=8000000L
 
 MysensorsMicro.menu.cpu.1Mhz=Atmega328 1Mhz
 MysensorsMicro.menu.cpu.1Mhz.build.f_cpu=1000000L
-
-
-########################################
-## Gateway settings
-
-MysensorsGW.name=Sensebender Gateway
-MysensorsGW.build.core=arduino:arduino
-MysensorsGW.build.variant=GW
-MysensorsGW.build.board=AVR_1284
-MysensorsGW.build.mcu=atmega1284p
-MysensorsGW.build.f_cpu=20000000L
-
-MysensorsGW.upload.tool=arduino:avrdude
-MysensorsGW.upload.protocol=arduino
-MysensorsGW.upload.maximum_size=123720
-MysensorsGW.upload.maximum_data_size=16384
-MysensorsGW.upload.speed=115200
-
-MysensorsGW.bootloader.tool=arduino:avrdude
-MysensorsGW.bootloader.unlock_bits=0x3F
-MysensorsGW.bootloader.lock_bits=0x0F
-MysensorsGW.bootloader.low_fuses=0xE2
-MysensorsGW.bootloader.high_fuses=0xD2
-MysensorsGW.bootloader.extended_fuses=0xFE
-MysensorsGW.bootloader.file=DualOptiboot/optiboot_atmega1284.hex

--- a/hardware/MySensors/avr/platform.txt
+++ b/hardware/MySensors/avr/platform.txt
@@ -5,7 +5,7 @@
 # For more info:
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
-name=MySensors Boards
+name=MySensors AVR based boards
 version=1.6.0
 
 # AVR compile variables


### PR DESCRIPTION
Updated platform.txt / boards.txt to reflect AVR platform target, and removed atmega1284 as GW target, since it is using atsamd21 instead.
