### PR TITLE
Use Tx/Rx pin as IO pin

### DIFF
--- a/libraries/MySensors/MyConfig.h
+++ b/libraries/MySensors/MyConfig.h
@@ -26,7 +26,7 @@
 // to see what is actually is happening when developing
 #define DEBUG
 
-//Comment this this line, If you are using TX(1), RX(0) as IO pin disable this
+// Disable this line, If you are using TX(1), RX(0) as normal I/O pin
 #define ENABLED_SERIAL
 
 // Serial output baud rate (for debug prints and serial gateway)

--- a/libraries/MySensors/MyConfig.h
+++ b/libraries/MySensors/MyConfig.h
@@ -26,6 +26,9 @@
 // to see what is actually is happening when developing
 #define DEBUG
 
+//Comment this this line, If you are using TX(1), RX(0) as IO pin disable this
+#define ENABLED_SERIAL
+
 // Serial output baud rate (for debug prints and serial gateway)
 #define BAUD_RATE 115200
 

--- a/libraries/MySensors/MyHwATMega328.cpp
+++ b/libraries/MySensors/MyHwATMega328.cpp
@@ -119,7 +119,9 @@ void powerDown(period_t period) {
 
 void MyHwATMega328::internalSleep(unsigned long ms) {
 	// Let serial prints finish (debug, log etc)
-	Serial.flush();
+  #ifdef ENABLED_SERIAL
+	  Serial.flush();
+  #endif
 	pinIntTrigger = 0;
 	while (!pinIntTrigger && ms >= 8000) { powerDown(SLEEP_8S); ms -= 8000; }
 	if (!pinIntTrigger && ms >= 4000)    { powerDown(SLEEP_4S); ms -= 4000; }
@@ -148,7 +150,9 @@ bool MyHwATMega328::sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
 			pinTriggeredWakeup = false;
 		}
 	} else {
-		Serial.flush();
+    #ifdef ENABLED_SERIAL
+		  Serial.flush();
+    #endif
 		powerDown(SLEEP_FOREVER);
 	}
 	detachInterrupt(interrupt);
@@ -166,7 +170,9 @@ inline uint8_t MyHwATMega328::sleep(uint8_t interrupt1, uint8_t mode1, uint8_t i
 			retVal = -1;
 		}
 	} else {
-		Serial.flush();
+    #ifdef ENABLED_SERIAL
+		  Serial.flush();
+    #endif
 		powerDown(SLEEP_FOREVER);
 	}
 	detachInterrupt(interrupt1);

--- a/libraries/MySensors/MySensor.cpp
+++ b/libraries/MySensors/MySensor.cpp
@@ -153,7 +153,9 @@ void MySensor::errBlink(uint8_t cnt) {
 #endif
 
 void MySensor::begin(void (*_msgCallback)(const MyMessage &), uint8_t _nodeId, boolean _repeaterMode, uint8_t _parentNodeId) {
-	hw_init();
+    #ifdef ENABLED_SERIAL
+	    hw_init();
+    #endif
 	repeaterMode = _repeaterMode;
 	msgCallback = _msgCallback;
 	failedTransmissions = 0;


### PR DESCRIPTION
With current design we could not use Tx/Rx as IO pin. I have added new variable 'ENABLED_SERIAL'. Disable this if you want to use Tx/Rx as IO pin in atmega328p.