### PR TITLE
Channel and Datarate in MyTransportNRF24 constructor

### DIFF
--- a/libraries/MySensors/MyTransportNRF24.cpp
+++ b/libraries/MySensors/MyTransportNRF24.cpp
@@ -20,11 +20,13 @@
 #include "MyTransport.h"
 #include "MyTransportNRF24.h"
 
-MyTransportNRF24::MyTransportNRF24(uint8_t ce, uint8_t cs, uint8_t paLevel)
+MyTransportNRF24::MyTransportNRF24(uint8_t ce, uint8_t cs, uint8_t paLevel, uint8_t channel, rf24_datarate_e datarate)
 	:
 	MyTransport(),
 	rf24(ce, cs),
-	_paLevel(paLevel)
+	_paLevel(paLevel),
+	_channel(channel),
+	_datarate(datarate)
 {
 }
 
@@ -38,9 +40,9 @@ bool MyTransportNRF24::init() {
 	rf24.setAutoAck(1);
 	rf24.setAutoAck(BROADCAST_PIPE,false); // Turn off auto ack for broadcast
 	rf24.enableAckPayload();
-	rf24.setChannel(RF24_CHANNEL);
+	rf24.setChannel(_channel);
 	rf24.setPALevel(_paLevel);
-	rf24.setDataRate(RF24_DATARATE);
+	rf24.setDataRate(_datarate);
 	rf24.setRetries(5,15);
 	rf24.setCRCLength(RF24_CRC_16);
 	rf24.enableDynamicPayloads();

--- a/libraries/MySensors/MyTransportNRF24.h
+++ b/libraries/MySensors/MyTransportNRF24.h
@@ -35,7 +35,7 @@
 class MyTransportNRF24 : public MyTransport
 { 
 public:
-	MyTransportNRF24(uint8_t ce=RF24_CE_PIN, uint8_t cs=RF24_CS_PIN, uint8_t paLevel=RF24_PA_LEVEL);
+	MyTransportNRF24(uint8_t ce=RF24_CE_PIN, uint8_t cs=RF24_CS_PIN, uint8_t paLevel=RF24_PA_LEVEL, uint8_t channel=RF24_CHANNEL, rf24_datarate_e datarate=RF24_DATARATE);
 	bool init();
 	void setAddress(uint8_t address);
 	uint8_t getAddress();
@@ -47,6 +47,9 @@ private:
 	RF24 rf24;
 	uint8_t _address;
 	uint8_t _paLevel;
+	uint8_t _paLevel;
+	uint8_t _channel;
+	rf24_datarate_e _datarate;
 };
 
 #endif

--- a/libraries/MySensors/MyTransportNRF24.h
+++ b/libraries/MySensors/MyTransportNRF24.h
@@ -47,7 +47,6 @@ private:
 	RF24 rf24;
 	uint8_t _address;
 	uint8_t _paLevel;
-	uint8_t _paLevel;
 	uint8_t _channel;
 	rf24_datarate_e _datarate;
 };


### PR DESCRIPTION
In v1.4 it was possible to change channel and datarate in the begin-statement.
This was very handy because I have a test-system with different channel next to a productive system. I do not want to edit MyConfig.h every time I compile something for the test-system.
