### PR TITLE
Forward declare all inline functions

### DIFF
--- a/libraries/MySensors/examples/MQTTClientGateway/MQTTClientGateway.ino
+++ b/libraries/MySensors/examples/MQTTClientGateway/MQTTClientGateway.ino
@@ -162,6 +162,8 @@ volatile uint8_t countErr;
 
 void processMQTTMessages(char* topic, byte* payload, unsigned int length);
 PubSubClient client(remote_ip, remote_port, processMQTTMessages, ethClient);
+inline MyMessage& build(MyMessage &msg, uint8_t sender, uint8_t destination, uint8_t sensor,
+                        uint8_t command, uint8_t type, bool enableAck);
 
 ////////////////////////////////////////////////////////////////
 

--- a/libraries/MySensors/examples/MQTTGateway/MQTTGateway.ino
+++ b/libraries/MySensors/examples/MQTTGateway/MQTTGateway.ino
@@ -132,6 +132,7 @@ MyHwATMega328 hw;
 // Construct MySensors library (signer needed if MY_SIGNING_FEATURE is turned on in MyConfig.h)
 MySensor gw(transport, hw /*, signer*/);
 
+inline MyMessage& build (MyMessage &msg, uint8_t destination, uint8_t sensor, uint8_t command, uint8_t type, bool enableAck);
 
 EthernetServer server = EthernetServer(TCP_PORT);
 EthernetClient *currentClient = NULL;


### PR DESCRIPTION
This seem to be mandatory for newer Arduino IDE versions.