### PR TITLE
HeatpumpIR library updated to Arduino IDE 1.6 PROGMEM definition

### DIFF
--- a/libraries/HeatpumpIR/CarrierHeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/CarrierHeatpumpIR.cpp
@@ -10,16 +10,16 @@ CarrierHeatpumpIR::CarrierHeatpumpIR() : HeatpumpIR()
 }
 
 
-void CarrierHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd)
+void CarrierHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
   (void)swingVCmd;
   (void)swingHCmd;
 
   // Sensible defaults for the heat pump mode
 
-  byte operatingMode = CARRIER_AIRCON1_MODE_HEAT;
-  byte fanSpeed = CARRIER_AIRCON1_FAN_AUTO;
-  byte temperature = 23;
+  uint8_t operatingMode = CARRIER_AIRCON1_MODE_HEAT;
+  uint8_t fanSpeed = CARRIER_AIRCON1_FAN_AUTO;
+  uint8_t temperature = 23;
 
   if (powerModeCmd == POWER_OFF)
   {
@@ -82,12 +82,12 @@ void CarrierHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingMode
 // Send the Carrier code
 // Carrier has the LSB and MSB in different format than Panasonic
 
-void CarrierHeatpumpIR::sendCarrier(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature)
+void CarrierHeatpumpIR::sendCarrier(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature)
 {
-  byte sendBuffer[9] = { 0x4f, 0xb0, 0xc0, 0x3f, 0x80, 0x00, 0x00, 0x00, 0x00 }; // The data is on the last four bytes
+  uint8_t sendBuffer[9] = { 0x4f, 0xb0, 0xc0, 0x3f, 0x80, 0x00, 0x00, 0x00, 0x00 }; // The data is on the last four uint8_ts
 
-  static const prog_uint8_t temperatures[] PROGMEM = { 0x00, 0x08, 0x04, 0x0c, 0x02, 0x0a, 0x06, 0x0e, 0x01, 0x09, 0x05, 0x0d, 0x03, 0x0b };
-  byte checksum = 0;
+  static const uint8_t temperatures[] PROGMEM = { 0x00, 0x08, 0x04, 0x0c, 0x02, 0x0a, 0x06, 0x0e, 0x01, 0x09, 0x05, 0x0d, 0x03, 0x0b };
+  uint8_t checksum = 0;
 
   // PROGMEM arrays cannot be addressed directly, see http://forum.arduino.cc/index.php?topic=106603.0
   sendBuffer[5] = pgm_read_byte(&(temperatures[(temperature-17)]));
@@ -149,7 +149,7 @@ void CarrierHeatpumpIR::sendCarrier(IRSender& IR, byte operatingMode, byte fanSp
 
   // Payload
   for (size_t i=0; i<sizeof(sendBuffer); i++) {
-    IR.sendIRByte(sendBuffer[i], CARRIER_AIRCON1_BIT_MARK, CARRIER_AIRCON1_ZERO_SPACE, CARRIER_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[i], CARRIER_AIRCON1_BIT_MARK, CARRIER_AIRCON1_ZERO_SPACE, CARRIER_AIRCON1_ONE_SPACE);
   }
 
   // Pause + new header
@@ -161,7 +161,7 @@ void CarrierHeatpumpIR::sendCarrier(IRSender& IR, byte operatingMode, byte fanSp
 
   // Payload again
   for (size_t i=0; i<sizeof(sendBuffer); i++) {
-    IR.sendIRByte(sendBuffer[i], CARRIER_AIRCON1_BIT_MARK, CARRIER_AIRCON1_ZERO_SPACE, CARRIER_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[i], CARRIER_AIRCON1_BIT_MARK, CARRIER_AIRCON1_ZERO_SPACE, CARRIER_AIRCON1_ONE_SPACE);
   }
 
   // End mark

--- a/libraries/HeatpumpIR/CarrierHeatpumpIR.h
+++ b/libraries/HeatpumpIR/CarrierHeatpumpIR.h
@@ -33,10 +33,10 @@ class CarrierHeatpumpIR : public HeatpumpIR
 {
   public:
     CarrierHeatpumpIR();
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:
-    void sendCarrier(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature);
+    void sendCarrier(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature);
 };
 
 #endif

--- a/libraries/HeatpumpIR/FujitsuHeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/FujitsuHeatpumpIR.cpp
@@ -10,22 +10,22 @@ FujitsuHeatpumpIR::FujitsuHeatpumpIR() : HeatpumpIR()
 }
 
 
-void FujitsuHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd)
+void FujitsuHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
   send(IR,  powerModeCmd, operatingModeCmd, fanSpeedCmd, temperatureCmd, swingVCmd, swingHCmd, false);
 }
 
 
-void FujitsuHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd, bool ecoModeCmd)
+void FujitsuHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool ecoModeCmd)
 {
   // Sensible defaults for the heat pump mode
 
-  byte operatingMode = FUJITSU_AIRCON1_MODE_HEAT;
-  byte fanSpeed = FUJITSU_AIRCON1_FAN_AUTO;
-  byte temperature = 23;
-  byte swingV = FUJITSU_AIRCON1_VDIR_MANUAL;
-  byte swingH = FUJITSU_AIRCON1_HDIR_MANUAL;
-  byte ecoMode = FUJITSU_AIRCON1_ECO_OFF;
+  uint8_t operatingMode = FUJITSU_AIRCON1_MODE_HEAT;
+  uint8_t fanSpeed = FUJITSU_AIRCON1_FAN_AUTO;
+  uint8_t temperature = 23;
+  uint8_t swingV = FUJITSU_AIRCON1_VDIR_MANUAL;
+  uint8_t swingH = FUJITSU_AIRCON1_HDIR_MANUAL;
+  uint8_t ecoMode = FUJITSU_AIRCON1_ECO_OFF;
 
   if (powerModeCmd == POWER_OFF)
   {
@@ -49,7 +49,7 @@ void FujitsuHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingMode
         break;
       case MODE_FAN:
         operatingMode = FUJITSU_AIRCON1_MODE_FAN;
-        // When Fujitsu goes to FAN mode, it sets the low bit of the byte with the temperature. What is the meaning of that?
+        // When Fujitsu goes to FAN mode, it sets the low bit of the uint8_t with the temperature. What is the meaning of that?
        break;
     }
   }
@@ -95,21 +95,21 @@ void FujitsuHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingMode
 }
 
 
-void FujitsuHeatpumpIR::sendFujitsu(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature, byte swingV, byte swingH, byte ecoMode)
+void FujitsuHeatpumpIR::sendFujitsu(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, uint8_t ecoMode)
 {
   // ON, HEAT, AUTO FAN, +24 degrees
-  byte FujitsuTemplate[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30, 0x80, 0x04, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00 };
+  uint8_t FujitsuTemplate[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30, 0x80, 0x04, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00 };
   //                            0     1     2     3     4     5     6     7     8     9    10    11    12    13    14    15
 
-  byte OFF_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x02, 0xFD };
-  byte checksum = 0x00;
+  uint8_t OFF_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x02, 0xFD };
+  uint8_t checksum = 0x00;
 
 /*
 
   Fujitsu does not have codes to set the air direction to any specific position, but just go to the next position:
 
-  byte nextVerticalPosition_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x6C, 0x93 };
-  byte nextHorizontalPosition_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x79,0x86 };
+  uint8_t nextVerticalPosition_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x6C, 0x93 };
+  uint8_t nextHorizontalPosition_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x79,0x86 };
 
   These would need to be sent separately...
 */
@@ -130,7 +130,7 @@ void FujitsuHeatpumpIR::sendFujitsu(IRSender& IR, byte operatingMode, byte fanSp
     checksum += FujitsuTemplate[i];
   }
 
-  FujitsuTemplate[15] = (byte)(0x9E - checksum);
+  FujitsuTemplate[15] = (uint8_t)(0x9E - checksum);
 
   if (operatingMode == FUJITSU_AIRCON1_MODE_OFF) {
     // OFF
@@ -143,7 +143,7 @@ void FujitsuHeatpumpIR::sendFujitsu(IRSender& IR, byte operatingMode, byte fanSp
 
 void FujitsuHeatpumpIR::sendFujitsuHiPower(IRSender& IR)
 {
-  byte HiPower_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x39, 0xC6 };
+  uint8_t HiPower_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x39, 0xC6 };
 
   sendFujitsuMsg(IR, sizeof(HiPower_msg), HiPower_msg);
 }
@@ -151,7 +151,7 @@ void FujitsuHeatpumpIR::sendFujitsuHiPower(IRSender& IR)
 
 void FujitsuHeatpumpIR::sendFujitsuFilterClean(IRSender& IR)
 {
-  byte FilterClean_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x02, 0xFD };
+  uint8_t FilterClean_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x02, 0xFD };
 
   sendFujitsuMsg(IR, sizeof(FilterClean_msg), FilterClean_msg);
 }
@@ -159,7 +159,7 @@ void FujitsuHeatpumpIR::sendFujitsuFilterClean(IRSender& IR)
 
 void FujitsuHeatpumpIR::sendFujitsuSuperQuiet(IRSender& IR)
 {
-  byte SuperQuiet_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x02, 0xFD };
+  uint8_t SuperQuiet_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x02, 0xFD };
 
   sendFujitsuMsg(IR, sizeof(SuperQuiet_msg), SuperQuiet_msg);
 }
@@ -167,13 +167,13 @@ void FujitsuHeatpumpIR::sendFujitsuSuperQuiet(IRSender& IR)
 
 void FujitsuHeatpumpIR::sendFujitsuTestRun(IRSender& IR)
 {
-  byte TestRun_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x02, 0xFD };
+  uint8_t TestRun_msg[] = { 0x14, 0x63, 0x00, 0x10, 0x10, 0x02, 0xFD };
 
   sendFujitsuMsg(IR, sizeof(TestRun_msg), TestRun_msg);
 }
 
 
-void FujitsuHeatpumpIR::sendFujitsuMsg(IRSender& IR, byte msgSize, byte *msg)
+void FujitsuHeatpumpIR::sendFujitsuMsg(IRSender& IR, uint8_t msgSize, uint8_t *msg)
 {
   // 40 kHz PWM frequency
   IR.setFrequency(40);
@@ -183,8 +183,8 @@ void FujitsuHeatpumpIR::sendFujitsuMsg(IRSender& IR, byte msgSize, byte *msg)
   IR.space(FUJITSU_AIRCON1_HDR_SPACE);
 
   // Data
-  for (byte i=0; i<msgSize; i++) {
-      IR.sendIRByte(msg[i], FUJITSU_AIRCON1_BIT_MARK, FUJITSU_AIRCON1_ZERO_SPACE, FUJITSU_AIRCON1_ONE_SPACE);
+  for (uint8_t i=0; i<msgSize; i++) {
+      IR.sendIRbyte(msg[i], FUJITSU_AIRCON1_BIT_MARK, FUJITSU_AIRCON1_ZERO_SPACE, FUJITSU_AIRCON1_ONE_SPACE);
   }
 
   // End mark

--- a/libraries/HeatpumpIR/FujitsuHeatpumpIR.h
+++ b/libraries/HeatpumpIR/FujitsuHeatpumpIR.h
@@ -39,16 +39,16 @@ class FujitsuHeatpumpIR : public HeatpumpIR
 {
   public:
     FujitsuHeatpumpIR();
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd, bool ecoModeCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd, bool ecoModeCmd);
     void sendFujitsuHiPower(IRSender& IR);
     void sendFujitsuFilterClean(IRSender& IR);
     void sendFujitsuSuperQuiet(IRSender& IR);
     void sendFujitsuTestRun(IRSender& IR);
 
   private:
-    void sendFujitsu(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature, byte swingV, byte swingH, byte ecoMode);
-    void sendFujitsuMsg(IRSender& IR, byte msgSize, byte *msg);
+    void sendFujitsu(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH, uint8_t ecoMode);
+    void sendFujitsuMsg(IRSender& IR, uint8_t msgSize, uint8_t *msg);
 };
 
 #endif

--- a/libraries/HeatpumpIR/HeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/HeatpumpIR.cpp
@@ -5,7 +5,7 @@ HeatpumpIR::HeatpumpIR()
 }
 
 // This is a virtual function, i.e. never called
-void HeatpumpIR::send(IRSender&, byte, byte, byte, byte, byte, byte)
+void HeatpumpIR::send(IRSender&, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t)
 {
 }
 

--- a/libraries/HeatpumpIR/HeatpumpIR.h
+++ b/libraries/HeatpumpIR/HeatpumpIR.h
@@ -7,7 +7,6 @@
 #ifndef HeatpumpIR_h
 #define HeatpumpIR_h
 
-#define __PROG_TYPES_COMPAT__
 #include <Arduino.h>
 #include <IRSender.h>
 
@@ -61,7 +60,7 @@ class HeatpumpIR
     const char * _info;
 
   public:
-    virtual void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
+    virtual void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     const char PROGMEM* model();
     const char PROGMEM* info();
 };

--- a/libraries/HeatpumpIR/HisenseHeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/HisenseHeatpumpIR.cpp
@@ -10,19 +10,19 @@ HisenseHeatpumpIR::HisenseHeatpumpIR() : HeatpumpIR()
 }
 
 
-void HisenseHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd , byte fanSpeedCmd , byte temperatureCmd , byte swingVCmd , byte swingHCmd )
+void HisenseHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd , uint8_t fanSpeedCmd , uint8_t temperatureCmd , uint8_t swingVCmd , uint8_t swingHCmd )
 {
   (void)swingVCmd;
   (void)swingHCmd;
 
   // Sensible defaults for the heat pump mode
 
-  byte powerMode = HISENSE_AIRCON1_POWER_ON;
-  byte operatingMode = HISENSE_AIRCON1_MODE_HEAT;
-  byte fanSpeed = HISENSE_AIRCON1_FAN_AUTO;
-  byte temperature = 21;
-  byte swingV=0;
-  byte swingH=0;
+  uint8_t powerMode = HISENSE_AIRCON1_POWER_ON;
+  uint8_t operatingMode = HISENSE_AIRCON1_MODE_HEAT;
+  uint8_t fanSpeed = HISENSE_AIRCON1_FAN_AUTO;
+  uint8_t temperature = 21;
+  uint8_t swingV=0;
+  uint8_t swingH=0;
 
   if (powerModeCmd == POWER_OFF)
   {
@@ -82,21 +82,21 @@ void HisenseHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingMode
 }
 
 // Send the Hisense code
-void HisenseHeatpumpIR::sendHisense(IRSender& IR, byte powerMode, byte operatingMode, byte fanSpeed, byte temperature, byte swingV ,byte swingH)
+void HisenseHeatpumpIR::sendHisense(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV ,uint8_t swingH)
 {
   (void)swingV;
   (void)swingH;
 
-  byte HisenseTemplate[] = { 0x87, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,    // Header byte 0-1
+  uint8_t HisenseTemplate[] = { 0x87, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00,    // Header uint8_t 0-1
                              0x00, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00 };  //
 
-  byte  i;
+  uint8_t  i;
 
   // Set the Fan speed, On/Off.
   HisenseTemplate[2] = fanSpeed | powerMode;
   HisenseTemplate[3] =  (((temperature - 18)  << 4)  | operatingMode ) ;
 
-  // Calculate the byte checksum EXOR byte 2 to 12
+  // Calculate the uint8_t checksum EXOR uint8_t 2 to 12
   HisenseTemplate[13] = HisenseTemplate[2];
   for (i=3; i<13; i++) {
      HisenseTemplate[13]= HisenseTemplate[i] ^ HisenseTemplate[13];
@@ -111,7 +111,7 @@ void HisenseHeatpumpIR::sendHisense(IRSender& IR, byte powerMode, byte operating
 
   // Payload header part
   for (i=0; i<7; i++) {
-    IR.sendIRByte(HisenseTemplate[i], HISENSE_AIRCON1_BIT_MARK, HISENSE_AIRCON1_ZERO_SPACE, HISENSE_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(HisenseTemplate[i], HISENSE_AIRCON1_BIT_MARK, HISENSE_AIRCON1_ZERO_SPACE, HISENSE_AIRCON1_ONE_SPACE);
   }
 
   // Mesage space
@@ -120,7 +120,7 @@ void HisenseHeatpumpIR::sendHisense(IRSender& IR, byte powerMode, byte operating
 
   // Payload message part
   for (; i<14; i++) {
-    IR.sendIRByte(HisenseTemplate[i], HISENSE_AIRCON1_BIT_MARK, HISENSE_AIRCON1_ZERO_SPACE, HISENSE_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(HisenseTemplate[i], HISENSE_AIRCON1_BIT_MARK, HISENSE_AIRCON1_ZERO_SPACE, HISENSE_AIRCON1_ONE_SPACE);
   }
 
   // End mark

--- a/libraries/HeatpumpIR/HisenseHeatpumpIR.h
+++ b/libraries/HeatpumpIR/HisenseHeatpumpIR.h
@@ -64,10 +64,10 @@ class HisenseHeatpumpIR : public HeatpumpIR
 {
   public:
     HisenseHeatpumpIR();
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:
-    void sendHisense(IRSender& IR, byte powerMode, byte operatingMode, byte fanSpeed, byte temperature, byte swingV, byte swingH);
+    void sendHisense(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH);
 };
 
 #endif

--- a/libraries/HeatpumpIR/IRSender.cpp
+++ b/libraries/HeatpumpIR/IRSender.cpp
@@ -6,7 +6,7 @@
 //
 // For PWM on Arduino, see http://playground.arduino.cc/Main/TimerPWMCheatsheet
 
-IRSender::IRSender(byte pin)
+IRSender::IRSender(uint8_t pin)
 {
   _pin = pin;
 }
@@ -72,8 +72,8 @@ void IRSender::setFrequency(int frequency)
   }
 }
 
-// Send a byte (8 bits) over IR
-void IRSender::sendIRByte(byte sendByte, int bitMarkLength, int zeroSpaceLength, int oneSpaceLength)
+// Send a uint8_t (8 bits) over IR
+void IRSender::sendIRbyte(uint8_t sendByte, int bitMarkLength, int zeroSpaceLength, int oneSpaceLength)
 {
   for (int i=0; i<8 ; i++)
   {
@@ -93,8 +93,8 @@ void IRSender::sendIRByte(byte sendByte, int bitMarkLength, int zeroSpaceLength,
 }
 
 // The Carrier IR protocol has the bits in a reverse order (compared to the other heatpumps)
-// See http://www.nrtm.org/index.php/2013/07/25/reverse-bits-in-a-byte/
-byte IRSender::bitReverse(byte x)
+// See http://www.nrtm.org/index.php/2013/07/25/reverse-bits-in-a-uint8_t/
+uint8_t IRSender::bitReverse(uint8_t x)
 {
   //          01010101  |         10101010
   x = ((x >> 1) & 0x55) | ((x << 1) & 0xaa);

--- a/libraries/HeatpumpIR/IRSender.h
+++ b/libraries/HeatpumpIR/IRSender.h
@@ -9,15 +9,15 @@
 class IRSender
 {
   public:
-    IRSender(byte pin);
+    IRSender(uint8_t pin);
     void setFrequency(int frequency);
-    void sendIRByte(byte sendByte, int bitMarkLength, int zeroSpaceLength, int oneSpaceLength);
-    byte bitReverse(byte x);
+    void sendIRbyte(uint8_t sendByte, int bitMarkLength, int zeroSpaceLength, int oneSpaceLength);
+    uint8_t bitReverse(uint8_t x);
     void space(int spaceLength);
     void mark(int markLength);
 
   private:
-    byte _pin;
+    uint8_t _pin;
 };
 
 #endif

--- a/libraries/HeatpumpIR/MideaHeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/MideaHeatpumpIR.cpp
@@ -10,15 +10,15 @@ MideaHeatpumpIR::MideaHeatpumpIR() : HeatpumpIR()
 }
 
 
-void MideaHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd)
+void MideaHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
   (void)swingVCmd;
   (void)swingHCmd;
 
   // Sensible defaults for the heat pump mode
-  byte operatingMode = MIDEA_AIRCON1_MODE_HEAT;
-  byte fanSpeed = MIDEA_AIRCON1_FAN_AUTO;
-  byte temperature = 23;
+  uint8_t operatingMode = MIDEA_AIRCON1_MODE_HEAT;
+  uint8_t fanSpeed = MIDEA_AIRCON1_FAN_AUTO;
+  uint8_t temperature = 23;
 
   switch (powerModeCmd)
   {
@@ -48,8 +48,8 @@ void MideaHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCm
       break;
     case MODE_MAINT:
       // Maintenance mode ('FP' on the remote) is a special mode on Midea
-	  // Also, this is a switch between 'normal' operation and 'maintenance' operation,
-	  // i.e. if already running on maintenance, the heatpump will go back to normal operation
+      // Also, this is a switch between 'normal' operation and 'maintenance' operation,
+      // i.e. if already running on maintenance, the heatpump will go back to normal operation
       operatingMode = MIDEA_AIRCON1_MODE_FP;
       break;
   }
@@ -79,14 +79,14 @@ void MideaHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCm
 }
 
 // Send the Midea code
-void MideaHeatpumpIR::sendMidea(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature)
+void MideaHeatpumpIR::sendMidea(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature)
 {
-  byte sendBuffer[3] = { 0x4D, 0x00, 0x00 }; // First byte is always 0x4D
+  uint8_t sendBuffer[3] = { 0x4D, 0x00, 0x00 }; // First uint8_t is always 0x4D
 
-  static const prog_uint8_t temperatures[] PROGMEM = {0, 8, 12, 4, 6, 14, 10, 2, 3, 11, 9, 1, 5, 13 };
+  static const uint8_t temperatures[] PROGMEM = {0, 8, 12, 4, 6, 14, 10, 2, 3, 11, 9, 1, 5, 13 };
 
-  static const prog_uint8_t OffMsg[] PROGMEM = {0x4D, 0xDE, 0x07 };
-  static const prog_uint8_t FPMsg[] PROGMEM =  {0xAD, 0xAF, 0xB5 };
+  static const uint8_t OffMsg[] PROGMEM = {0x4D, 0xDE, 0x07 };
+  static const uint8_t FPMsg[] PROGMEM =  {0xAD, 0xAF, 0xB5 };
 
   if (operatingMode == MIDEA_AIRCON1_MODE_OFF)
   {
@@ -115,7 +115,7 @@ void MideaHeatpumpIR::sendMidea(IRSender& IR, byte operatingMode, byte fanSpeed,
 }
 
 // Send the Midea raw code
-void MideaHeatpumpIR::sendMidearaw(IRSender& IR, byte sendBuffer[])
+void MideaHeatpumpIR::sendMidearaw(IRSender& IR, uint8_t sendBuffer[])
 {
   // 40 kHz PWM frequency
   IR.setFrequency(40);
@@ -124,24 +124,24 @@ void MideaHeatpumpIR::sendMidearaw(IRSender& IR, byte sendBuffer[])
   IR.mark(MIDEA_AIRCON1_HDR_MARK);
   IR.space(MIDEA_AIRCON1_HDR_SPACE);
 
-  // Six bytes, every second byte is a bitwise not of the previous byte
+  // Six uint8_ts, every second uint8_t is a bitwise not of the previous uint8_t
   for (int i=0; i<3; i++) {
-    IR.sendIRByte(sendBuffer[i], MIDEA_AIRCON1_BIT_MARK, MIDEA_AIRCON1_ZERO_SPACE, MIDEA_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(~sendBuffer[i], MIDEA_AIRCON1_BIT_MARK, MIDEA_AIRCON1_ZERO_SPACE, MIDEA_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[i], MIDEA_AIRCON1_BIT_MARK, MIDEA_AIRCON1_ZERO_SPACE, MIDEA_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(~sendBuffer[i], MIDEA_AIRCON1_BIT_MARK, MIDEA_AIRCON1_ZERO_SPACE, MIDEA_AIRCON1_ONE_SPACE);
   }
 
   // Pause
   IR.mark(MIDEA_AIRCON1_BIT_MARK);
   IR.space(MIDEA_AIRCON1_MSG_SPACE);
 
-  // Header, two last bytes repeated
+  // Header, two last uint8_ts repeated
   IR.mark(MIDEA_AIRCON1_HDR_MARK);
   IR.space(MIDEA_AIRCON1_HDR_SPACE);
 
-  // Six bytes, every second byte is a bitwise not of the previous byte
+  // Six uint8_ts, every second uint8_t is a bitwise not of the previous uint8_t
   for (int i=0; i<3; i++) {
-    IR.sendIRByte(sendBuffer[i], MIDEA_AIRCON1_BIT_MARK, MIDEA_AIRCON1_ZERO_SPACE, MIDEA_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(~sendBuffer[i], MIDEA_AIRCON1_BIT_MARK, MIDEA_AIRCON1_ZERO_SPACE, MIDEA_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[i], MIDEA_AIRCON1_BIT_MARK, MIDEA_AIRCON1_ZERO_SPACE, MIDEA_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(~sendBuffer[i], MIDEA_AIRCON1_BIT_MARK, MIDEA_AIRCON1_ZERO_SPACE, MIDEA_AIRCON1_ONE_SPACE);
   }
 
   // End mark

--- a/libraries/HeatpumpIR/MideaHeatpumpIR.h
+++ b/libraries/HeatpumpIR/MideaHeatpumpIR.h
@@ -37,11 +37,11 @@ class MideaHeatpumpIR : public HeatpumpIR
 {
   public:
     MideaHeatpumpIR();
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:
-    void sendMidea(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature);
-    void sendMidearaw(IRSender& IR, byte sendBuffer[]);
+    void sendMidea(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature);
+    void sendMidearaw(IRSender& IR, uint8_t sendBuffer[]);
 };
 
 #endif

--- a/libraries/HeatpumpIR/MitsubishiHeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/MitsubishiHeatpumpIR.cpp
@@ -31,16 +31,16 @@ MitsubishiFEHeatpumpIR::MitsubishiFEHeatpumpIR() : MitsubishiHeatpumpIR()
 }
 
 
-void MitsubishiHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd)
+void MitsubishiHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
   // Sensible defaults for the heat pump mode
 
-  byte powerMode     = MITSUBISHI_AIRCON1_MODE_ON;
-  byte operatingMode = MITSUBISHI_AIRCON1_MODE_HEAT;
-  byte fanSpeed      = MITSUBISHI_AIRCON1_FAN_AUTO;
-  byte temperature   = 23;
-  byte swingV        = MITSUBISHI_AIRCON1_VS_AUTO;
-  byte swingH        = MITSUBISHI_AIRCON1_HS_SWING;
+  uint8_t powerMode     = MITSUBISHI_AIRCON1_MODE_ON;
+  uint8_t operatingMode = MITSUBISHI_AIRCON1_MODE_HEAT;
+  uint8_t fanSpeed      = MITSUBISHI_AIRCON1_FAN_AUTO;
+  uint8_t temperature   = 23;
+  uint8_t swingV        = MITSUBISHI_AIRCON1_VS_AUTO;
+  uint8_t swingH        = MITSUBISHI_AIRCON1_HS_SWING;
 
   if (powerModeCmd == 0)
   {
@@ -155,12 +155,12 @@ void MitsubishiHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingM
   sendMitsubishi(IR, powerMode, operatingMode, fanSpeed, temperature, swingV, swingH);
 }
 
-void MitsubishiHeatpumpIR::sendMitsubishi(IRSender& IR, byte powerMode, byte operatingMode, byte fanSpeed, byte temperature, byte swingV, byte swingH)
+void MitsubishiHeatpumpIR::sendMitsubishi(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH)
 {
-  byte MitsubishiTemplate[] = { 0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x48, 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x10, 0x40, 0x00, 0x00 };
+  uint8_t MitsubishiTemplate[] = { 0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x48, 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x10, 0x40, 0x00, 0x00 };
   //                            0     1     2     3     4     5     6     7     8     9     10    11    12    13    14    15    16    17
 
-  byte checksum = 0x00;
+  uint8_t checksum = 0x00;
 
   // Set the operatingmode on the template message
   MitsubishiTemplate[5] = powerMode;
@@ -198,7 +198,7 @@ void MitsubishiHeatpumpIR::sendMitsubishi(IRSender& IR, byte powerMode, byte ope
 
     // Data
     for (unsigned int i=0; i<sizeof(MitsubishiTemplate); i++) {
-      IR.sendIRByte(MitsubishiTemplate[i], MITSUBISHI_AIRCON1_BIT_MARK, MITSUBISHI_AIRCON1_ZERO_SPACE, MITSUBISHI_AIRCON1_ONE_SPACE);
+      IR.sendIRbyte(MitsubishiTemplate[i], MITSUBISHI_AIRCON1_BIT_MARK, MITSUBISHI_AIRCON1_ZERO_SPACE, MITSUBISHI_AIRCON1_ONE_SPACE);
     }
 
     // Pause between the first and the second data burst

--- a/libraries/HeatpumpIR/MitsubishiHeatpumpIR.h
+++ b/libraries/HeatpumpIR/MitsubishiHeatpumpIR.h
@@ -55,13 +55,13 @@ class MitsubishiHeatpumpIR : public HeatpumpIR
 {
   protected: // Cannot create generic Mitsubishi heatpump instances
     MitsubishiHeatpumpIR();
-    byte _mitsubishiModel;  // Tells whether this is FD or EF (or other supported model...)
+    uint8_t _mitsubishiModel;  // Tells whether this is FD or EF (or other supported model...)
 
   public:
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:
-    void sendMitsubishi(IRSender& IR, byte powerMode, byte operatingMode, byte fanSpeed, byte temperature, byte swingVCmd, byte swingHCmd);
+    void sendMitsubishi(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingVCmd, uint8_t swingHCmd);
 };
 
 class MitsubishiFDHeatpumpIR : public MitsubishiHeatpumpIR

--- a/libraries/HeatpumpIR/PanasonicCKPHeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/PanasonicCKPHeatpumpIR.cpp
@@ -11,17 +11,17 @@ PanasonicCKPHeatpumpIR::PanasonicCKPHeatpumpIR()
 }
 
 
-// Panasonic CKP numeric values to command bytes
-void PanasonicCKPHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd)
+// Panasonic CKP numeric values to command uint8_ts
+void PanasonicCKPHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
   // Sensible defaults for the heat pump mode
 
-  byte powerMode     = false;
-  byte operatingMode = PANASONIC_AIRCON1_MODE_KEEP;
-  byte fanSpeed      = PANASONIC_AIRCON1_FAN_AUTO;
-  byte temperature   = 23;
-  byte swingV        = PANASONIC_AIRCON1_VS_UP;
-  byte swingH        = PANASONIC_AIRCON1_HS_SWING;
+  uint8_t powerMode     = false;
+  uint8_t operatingMode = PANASONIC_AIRCON1_MODE_KEEP;
+  uint8_t fanSpeed      = PANASONIC_AIRCON1_FAN_AUTO;
+  uint8_t temperature   = 23;
+  uint8_t swingV        = PANASONIC_AIRCON1_VS_UP;
+  uint8_t swingH        = PANASONIC_AIRCON1_HS_SWING;
 
   switch (powerModeCmd)
   {
@@ -134,9 +134,9 @@ void PanasonicCKPHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatin
 }
 
 // Send the Panasonic CKP code
-void PanasonicCKPHeatpumpIR::sendPanasonicCKP(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature, byte swingV, byte swingH)
+void PanasonicCKPHeatpumpIR::sendPanasonicCKP(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH)
 {
-  byte sendBuffer[4];
+  uint8_t sendBuffer[4];
 
   // Fan speed & temperature, temperature needs to be 27 in FAN mode
   if (operatingMode == PANASONIC_AIRCON1_MODE_FAN || operatingMode == (PANASONIC_AIRCON1_MODE_FAN | PANASONIC_AIRCON1_MODE_KEEP ))
@@ -160,20 +160,20 @@ void PanasonicCKPHeatpumpIR::sendPanasonicCKP(IRSender& IR, byte operatingMode, 
 }
 
 // Send the Panasonic CKP raw code
-void PanasonicCKPHeatpumpIR::sendPanasonicCKPraw(IRSender& IR, byte sendBuffer[])
+void PanasonicCKPHeatpumpIR::sendPanasonicCKPraw(IRSender& IR, uint8_t sendBuffer[])
 {
   // 40 kHz PWM frequency
   IR.setFrequency(40);
 
-  // Header, two first bytes repeated
+  // Header, two first uint8_ts repeated
   IR.mark(PANASONIC_AIRCON1_HDR_MARK);
   IR.space(PANASONIC_AIRCON1_HDR_SPACE);
 
   for (int i=0; i<2; i++) {
-    IR.sendIRByte(sendBuffer[0], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[0], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[1], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[1], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[0], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[0], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[1], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[1], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
 
     IR.mark(PANASONIC_AIRCON1_HDR_MARK);
     IR.space(PANASONIC_AIRCON1_HDR_SPACE);
@@ -184,16 +184,16 @@ void PanasonicCKPHeatpumpIR::sendPanasonicCKPraw(IRSender& IR, byte sendBuffer[]
   IR.mark(PANASONIC_AIRCON1_BIT_MARK);
   IR.space(PANASONIC_AIRCON1_MSG_SPACE);
 
-  // Header, two last bytes repeated
+  // Header, two last uint8_ts repeated
 
   IR.mark(PANASONIC_AIRCON1_HDR_MARK);
   IR.space(PANASONIC_AIRCON1_HDR_SPACE);
 
   for (int i=0; i<2; i++) {
-    IR.sendIRByte(sendBuffer[2], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[2], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[3], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[3], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[2], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[2], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[3], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[3], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
 
     IR.mark(PANASONIC_AIRCON1_HDR_MARK);
     IR.space(PANASONIC_AIRCON1_HDR_SPACE);
@@ -212,12 +212,12 @@ void PanasonicCKPHeatpumpIR::sendPanasonicCKPraw(IRSender& IR, byte sendBuffer[]
 // * a timer event is scheduled to cancel the timer after TWO minutes (the 'TIMER' led turns off
 void PanasonicCKPHeatpumpIR::sendPanasonicCKPOnOffTimerCancel(IRSender& IR, boolean powerState, boolean cancelTimer)
 {
-  static const prog_uint8_t ON_msg[] PROGMEM =     { 0x7F, 0x38, 0xBF, 0x38, 0x10, 0x3D, 0x80, 0x3D, 0x09, 0x34, 0x80, 0x34 }; //  ON at 00:10, time now 00:09, no OFF timing
-  static const prog_uint8_t OFF_msg[] PROGMEM =    { 0x10, 0x38, 0x80, 0x38, 0x7F, 0x3D, 0xBF, 0x3D, 0x09, 0x34, 0x80, 0x34 }; // OFF at 00:10, time now 00:09, no ON timing
-  static const prog_uint8_t CANCEL_msg[] PROGMEM = { 0x7F, 0x38, 0xBF, 0x38, 0x7F, 0x3D, 0xBF, 0x3D, 0x17, 0x34, 0x80, 0x34 }; // Timer CANCEL
+  static const uint8_t ON_msg[] PROGMEM =     { 0x7F, 0x38, 0xBF, 0x38, 0x10, 0x3D, 0x80, 0x3D, 0x09, 0x34, 0x80, 0x34 }; //  ON at 00:10, time now 00:09, no OFF timing
+  static const uint8_t OFF_msg[] PROGMEM =    { 0x10, 0x38, 0x80, 0x38, 0x7F, 0x3D, 0xBF, 0x3D, 0x09, 0x34, 0x80, 0x34 }; // OFF at 00:10, time now 00:09, no ON timing
+  static const uint8_t CANCEL_msg[] PROGMEM = { 0x7F, 0x38, 0xBF, 0x38, 0x7F, 0x3D, 0xBF, 0x3D, 0x17, 0x34, 0x80, 0x34 }; // Timer CANCEL
 
   // Save some SRAM by only having one copy of the template on the SRAM
-  byte sendBuffer[sizeof(ON_msg)];
+  uint8_t sendBuffer[sizeof(ON_msg)];
 
   if ( cancelTimer == true ) {
     memcpy_P(sendBuffer, CANCEL_msg, sizeof(ON_msg));
@@ -234,10 +234,10 @@ void PanasonicCKPHeatpumpIR::sendPanasonicCKPOnOffTimerCancel(IRSender& IR, bool
     IR.mark(PANASONIC_AIRCON1_HDR_MARK);
     IR.space(PANASONIC_AIRCON1_HDR_SPACE);
 
-    IR.sendIRByte(sendBuffer[i*2 + 0], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[i*2 + 0], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[i*2 + 1], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
-    IR.sendIRByte(sendBuffer[i*2 + 1], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[i*2 + 0], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[i*2 + 0], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[i*2 + 1], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(sendBuffer[i*2 + 1], PANASONIC_AIRCON1_BIT_MARK, PANASONIC_AIRCON1_ZERO_SPACE, PANASONIC_AIRCON1_ONE_SPACE);
 
     IR.mark(PANASONIC_AIRCON1_HDR_MARK);
     IR.space(PANASONIC_AIRCON1_HDR_SPACE);

--- a/libraries/HeatpumpIR/PanasonicCKPHeatpumpIR.h
+++ b/libraries/HeatpumpIR/PanasonicCKPHeatpumpIR.h
@@ -43,12 +43,12 @@ class PanasonicCKPHeatpumpIR : public HeatpumpIR
 {
   public:
     PanasonicCKPHeatpumpIR();
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
     void sendPanasonicCKPCancelTimer(IRSender& IR);
 
   private:
-    void sendPanasonicCKP(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature, byte swingV, byte swingH);
-    void sendPanasonicCKPraw(IRSender& IR, byte sendBuffer[]);
+    void sendPanasonicCKP(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH);
+    void sendPanasonicCKPraw(IRSender& IR, uint8_t sendBuffer[]);
     void sendPanasonicCKPOnOffTimerCancel(IRSender& IR, boolean powerState, boolean cancelTimer);
 };
 

--- a/libraries/HeatpumpIR/PanasonicHeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/PanasonicHeatpumpIR.cpp
@@ -41,16 +41,16 @@ PanasonicNKEHeatpumpIR::PanasonicNKEHeatpumpIR() : PanasonicHeatpumpIR()
 }
 
 
-// Panasonic DKE/NKE/JKE numeric values to command bytes
-void PanasonicHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd)
+// Panasonic DKE/NKE/JKE numeric values to command uint8_ts
+void PanasonicHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
   // Sensible defaults for the heat pump mode
 
-  byte operatingMode = PANASONIC_AIRCON2_TIMER_CNL;
-  byte fanSpeed      = PANASONIC_AIRCON2_FAN_AUTO;
-  byte temperature   = 23;
-  byte swingV        = PANASONIC_AIRCON2_VS_UP;
-  byte swingH        = PANASONIC_AIRCON2_HS_AUTO;
+  uint8_t operatingMode = PANASONIC_AIRCON2_TIMER_CNL;
+  uint8_t fanSpeed      = PANASONIC_AIRCON2_FAN_AUTO;
+  uint8_t temperature   = 23;
+  uint8_t swingV        = PANASONIC_AIRCON2_VS_UP;
+  uint8_t swingH        = PANASONIC_AIRCON2_HS_AUTO;
 
   switch (powerModeCmd)
   {
@@ -171,10 +171,10 @@ void PanasonicHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingMo
 }
 
 // Send the Panasonic DKE/JKE/NKE code
-void PanasonicHeatpumpIR::sendPanasonic(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature, byte swingV, byte swingH)
+void PanasonicHeatpumpIR::sendPanasonic(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH)
 {
-  // Only bytes 13, 14, 16, 17 and 26 are modified, DKE and JKE seem to share the same template?
-  static const prog_uint8_t panasonicProgmemTemplate[][27] PROGMEM = {
+  // Only uint8_ts 13, 14, 16, 17 and 26 are modified, DKE and JKE seem to share the same template?
+  static const uint8_t panasonicProgmemTemplate[][27] PROGMEM = {
     // DKE, model 0
     { 0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06, 0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x0E, 0xE0, 0x00, 0x00, 0x01, 0x00, 0x06, 0x00 },
     // JKE, model 1
@@ -185,7 +185,7 @@ void PanasonicHeatpumpIR::sendPanasonic(IRSender& IR, byte operatingMode, byte f
   };
 
   // Save some SRAM by only having one copy of the template on the SRAM
-  byte panasonicTemplate[27];
+  uint8_t panasonicTemplate[27];
   memcpy_P(panasonicTemplate, panasonicProgmemTemplate[_panasonicModel], sizeof(panasonicTemplate));
 
   panasonicTemplate[13] = operatingMode;
@@ -199,7 +199,7 @@ void PanasonicHeatpumpIR::sendPanasonic(IRSender& IR, byte operatingMode, byte f
 
   // Checksum calculation
 
-  byte checksum = 0xF4;
+  uint8_t checksum = 0xF4;
 
   for (int i=0; i<26; i++) {
     checksum += panasonicTemplate[i];
@@ -214,9 +214,9 @@ void PanasonicHeatpumpIR::sendPanasonic(IRSender& IR, byte operatingMode, byte f
   IR.mark(PANASONIC_AIRCON2_HDR_MARK);
   IR.space(PANASONIC_AIRCON2_HDR_SPACE);
 
-  // First 8 bytes
+  // First 8 uint8_ts
   for (int i=0; i<8; i++) {
-    IR.sendIRByte(panasonicTemplate[i], PANASONIC_AIRCON2_BIT_MARK, PANASONIC_AIRCON2_ZERO_SPACE, PANASONIC_AIRCON2_ONE_SPACE);
+    IR.sendIRbyte(panasonicTemplate[i], PANASONIC_AIRCON2_BIT_MARK, PANASONIC_AIRCON2_ZERO_SPACE, PANASONIC_AIRCON2_ONE_SPACE);
   }
 
   // Pause
@@ -227,9 +227,9 @@ void PanasonicHeatpumpIR::sendPanasonic(IRSender& IR, byte operatingMode, byte f
   IR.mark(PANASONIC_AIRCON2_HDR_MARK);
   IR.space(PANASONIC_AIRCON2_HDR_SPACE);
 
-  // Last 19 bytes
+  // Last 19 uint8_ts
   for (int i=8; i<27; i++) {
-    IR.sendIRByte(panasonicTemplate[i], PANASONIC_AIRCON2_BIT_MARK, PANASONIC_AIRCON2_ZERO_SPACE, PANASONIC_AIRCON2_ONE_SPACE);
+    IR.sendIRbyte(panasonicTemplate[i], PANASONIC_AIRCON2_BIT_MARK, PANASONIC_AIRCON2_ZERO_SPACE, PANASONIC_AIRCON2_ONE_SPACE);
   }
 
   IR.mark(PANASONIC_AIRCON2_BIT_MARK);

--- a/libraries/HeatpumpIR/PanasonicHeatpumpIR.h
+++ b/libraries/HeatpumpIR/PanasonicHeatpumpIR.h
@@ -53,13 +53,13 @@ class PanasonicHeatpumpIR : public HeatpumpIR
 {
   protected: // Cannot create generic Panasonic heatpump instances
     PanasonicHeatpumpIR();
-    byte _panasonicModel;  // Tells whether this is DKE, NKE or JKE (or other supported model...)
+    uint8_t _panasonicModel;  // Tells whether this is DKE, NKE or JKE (or other supported model...)
 
   public:
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:
-    void sendPanasonic(IRSender& IR, byte operatingMode, byte fanSpeed, byte temperature, byte swingV, byte swingH);
+    void sendPanasonic(IRSender& IR, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV, uint8_t swingH);
 };
 
 class PanasonicDKEHeatpumpIR : public PanasonicHeatpumpIR

--- a/libraries/HeatpumpIR/README.md
+++ b/libraries/HeatpumpIR/README.md
@@ -1,5 +1,6 @@
-arduino-heatpumpir
-==================
+# arduino-heatpumpir
+
+Original location: https://github.com/ToniA/arduino-heatpumpir
 
 An Arduino library to control a Panasonic, Midea, Carrier, Fujitsu or Mitsubishi heat pump/split unit air conditioner.
 Currently supports at least these models 
@@ -13,8 +14,8 @@ Currently supports at least these models
 * Hisense AUD (remote control Y-H1-01,  Y-H1-02(E), Y-J1, Y-E4-07) probably AUC model
 
 
-Instructions
-------------
+## Instructions
+
 * Download the library, and place it under your personal Arduino 'libraries' directory, under directory 'HeatpumpIR'
 * See the example sketches
 

--- a/libraries/HeatpumpIR/SamsungHeatpumpIR.cpp
+++ b/libraries/HeatpumpIR/SamsungHeatpumpIR.cpp
@@ -10,18 +10,18 @@ SamsungHeatpumpIR::SamsungHeatpumpIR() : HeatpumpIR()
 }
 
 
-void SamsungHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd)
+void SamsungHeatpumpIR::send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd)
 {
   (void)swingVCmd;
   (void)swingHCmd;
 
   // Sensible defaults for the heat pump mode
 
-  byte powerMode = SAMSUNG_AIRCON1_MODE_ON;
-  byte operatingMode = SAMSUNG_AIRCON1_MODE_HEAT;
-  byte fanSpeed = SAMSUNG_AIRCON1_FAN_AUTO;
-  byte temperature = 23;
-  byte swingV = SAMSUNG_AIRCON1_VS_AUTO;
+  uint8_t powerMode = SAMSUNG_AIRCON1_MODE_ON;
+  uint8_t operatingMode = SAMSUNG_AIRCON1_MODE_HEAT;
+  uint8_t fanSpeed = SAMSUNG_AIRCON1_FAN_AUTO;
+  uint8_t temperature = 23;
+  uint8_t swingV = SAMSUNG_AIRCON1_VS_AUTO;
 
   if (powerModeCmd == POWER_OFF)
   {
@@ -87,13 +87,13 @@ void SamsungHeatpumpIR::send(IRSender& IR, byte powerModeCmd, byte operatingMode
 
 // Send the Samsung code
 
-void SamsungHeatpumpIR::sendSamsung(IRSender& IR, byte powerMode, byte operatingMode, byte fanSpeed, byte temperature, byte swingV)
+void SamsungHeatpumpIR::sendSamsung(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV)
 {
-  byte SamsungTemplate[] = { 0x02, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00,   // Header part
+  uint8_t SamsungTemplate[] = { 0x02, 0x00, 0x0F, 0x00, 0x00, 0x00, 0x00,   // Header part
                              0x01, 0xD2, 0x0F, 0x00, 0x00, 0x00, 0x00,   // Always the same data on POWER messages
-                             0x01, 0x00, 0xFE, 0x71, 0x00, 0x00, 0x00 }; // The actual data is in this part, on bytes 14-20
+                             0x01, 0x00, 0xFE, 0x71, 0x00, 0x00, 0x00 }; // The actual data is in this part, on uint8_ts 14-20
 
-  byte SamsungChecksum = 0;
+  uint8_t SamsungChecksum = 0;
 
   // Set the power mode on the template message, also add the first part checksum
   SamsungTemplate[6] = powerMode;
@@ -114,15 +114,15 @@ void SamsungHeatpumpIR::sendSamsung(IRSender& IR, byte powerMode, byte operating
   // Set the vertical swing mode on the template message
   SamsungTemplate[16] = swingV;
 
-  // Calculate the byte 15 checksum
-  // Count the number of ONE bits on message bytes 15-20
-  for (byte j=15; j<21; j++) {
-    byte SamsungByte = SamsungTemplate[j];
-    for (byte i=0; i<8; i++) {
-      if ( (SamsungByte & 0x01) == 0x01 ) {
+  // Calculate the uint8_t 15 checksum
+  // Count the number of ONE bits on message uint8_ts 15-20
+  for (uint8_t j=15; j<21; j++) {
+    uint8_t Samsunguint8_t = SamsungTemplate[j];
+    for (uint8_t i=0; i<8; i++) {
+      if ( (Samsunguint8_t & 0x01) == 0x01 ) {
         SamsungChecksum++;
       }
-      SamsungByte >>= 1;
+      Samsunguint8_t >>= 1;
     }
   }
 
@@ -142,7 +142,7 @@ void SamsungHeatpumpIR::sendSamsung(IRSender& IR, byte powerMode, byte operating
 
   // Payload header part
   for (int i=0; i<7; i++) {
-    IR.sendIRByte(SamsungTemplate[i], SAMSUNG_AIRCON1_BIT_MARK, SAMSUNG_AIRCON1_ZERO_SPACE, SAMSUNG_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(SamsungTemplate[i], SAMSUNG_AIRCON1_BIT_MARK, SAMSUNG_AIRCON1_ZERO_SPACE, SAMSUNG_AIRCON1_ONE_SPACE);
   }
 
   // Pause + new header
@@ -154,7 +154,7 @@ void SamsungHeatpumpIR::sendSamsung(IRSender& IR, byte powerMode, byte operating
 
   // Payload power message part
   for (int i=7; i<14; i++) {
-    IR.sendIRByte(SamsungTemplate[i], SAMSUNG_AIRCON1_BIT_MARK, SAMSUNG_AIRCON1_ZERO_SPACE, SAMSUNG_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(SamsungTemplate[i], SAMSUNG_AIRCON1_BIT_MARK, SAMSUNG_AIRCON1_ZERO_SPACE, SAMSUNG_AIRCON1_ONE_SPACE);
   }
 
   // Pause + new header
@@ -166,7 +166,7 @@ void SamsungHeatpumpIR::sendSamsung(IRSender& IR, byte powerMode, byte operating
 
   // Payload data message part
   for (int i=14; i<21; i++) {
-    IR.sendIRByte(SamsungTemplate[i], SAMSUNG_AIRCON1_BIT_MARK, SAMSUNG_AIRCON1_ZERO_SPACE, SAMSUNG_AIRCON1_ONE_SPACE);
+    IR.sendIRbyte(SamsungTemplate[i], SAMSUNG_AIRCON1_BIT_MARK, SAMSUNG_AIRCON1_ZERO_SPACE, SAMSUNG_AIRCON1_ONE_SPACE);
   }
 
   // End mark

--- a/libraries/HeatpumpIR/SamsungHeatpumpIR.h
+++ b/libraries/HeatpumpIR/SamsungHeatpumpIR.h
@@ -33,10 +33,10 @@ class SamsungHeatpumpIR : public HeatpumpIR
 {
   public:
     SamsungHeatpumpIR();
-    void send(IRSender& IR, byte powerModeCmd, byte operatingModeCmd, byte fanSpeedCmd, byte temperatureCmd, byte swingVCmd, byte swingHCmd);
+    void send(IRSender& IR, uint8_t powerModeCmd, uint8_t operatingModeCmd, uint8_t fanSpeedCmd, uint8_t temperatureCmd, uint8_t swingVCmd, uint8_t swingHCmd);
 
   private:
-    void sendSamsung(IRSender& IR, byte powerMode, byte operatingMode, byte fanSpeed, byte temperature, byte swingV);
+    void sendSamsung(IRSender& IR, uint8_t powerMode, uint8_t operatingMode, uint8_t fanSpeed, uint8_t temperature, uint8_t swingV);
 };
 
 #endif

--- a/libraries/HeatpumpIR/examples/HisenseTest/HisenseTest.ino
+++ b/libraries/HeatpumpIR/examples/HisenseTest/HisenseTest.ino
@@ -1,47 +1,40 @@
+#include <Arduino.h>
 #include <HisenseHeatpumpIR.h>
 
 IRSender irSender(3); // IR led on Duemilanove digital pin 3
 
-HisenseHeatpumpIR *heatpumpIR;                        
+HisenseHeatpumpIR *heatpumpIR;
 
 void setup()
 {
-  
   Serial.begin(9600);
   delay(500);
   heatpumpIR = new HisenseHeatpumpIR();
   Serial.println(F("Starting"));
-    
-
-  
 }
 
 void loop()
 {
-  int i = 0;
-  prog_char* buf;
+  const char* buf;
 
-
-  // Send the same IR command to all supported heatpumps
   Serial.print(F("Sending IR to "));
     // Print the model
-  buf = (prog_char*)heatpumpIR->model();
+  buf = heatpumpIR->model();
   // 'model' is a PROGMEM pointer, so need to write a byte at a time
   while (char modelChar = pgm_read_byte(buf++))
   {
     Serial.print(modelChar);
   }
   Serial.print(F(", info: "));
- // Print the info 
-  buf = (prog_char*)heatpumpIR->info();
+ // Print the info
+  buf = heatpumpIR->info();
   // 'info' is a PROGMEM pointer, so need to write a byte at a time
   while (char infoChar = pgm_read_byte(buf++))
   {
     Serial.print(infoChar);
   }
-  Serial.println();  
+  Serial.println();
 
- 
   heatpumpIR->send(irSender, POWER_ON, MODE_HEAT, FAN_3, 30, VDIR_AUTO, HDIR_AUTO);
   delay(1500);
   heatpumpIR->send(irSender, POWER_ON, MODE_DRY,  FAN_2, 20, VDIR_AUTO, HDIR_AUTO);
@@ -50,7 +43,6 @@ void loop()
   delay(1500);
   heatpumpIR->send(irSender, POWER_ON, MODE_COOL, FAN_1, 18, VDIR_AUTO, HDIR_AUTO);
   delay(2500);
-  heatpumpIR->send(irSender, POWER_OFF, NULL, NULL, NULL, NULL, NULL);
+  heatpumpIR->send(irSender, POWER_OFF, MODE_COOL, FAN_1, 18, VDIR_AUTO, HDIR_AUTO);
   delay(1500);
-  
 }

--- a/libraries/HeatpumpIR/examples/MideaRelayControl/MideaRelayControl.ino
+++ b/libraries/HeatpumpIR/examples/MideaRelayControl/MideaRelayControl.ino
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <MideaHeatpumpIR.h>       // https://github.com/ToniA/arduino-heatpumpir
 #include <Button.h>                // http://playground.arduino.cc/Code/Button
 
@@ -34,8 +35,8 @@ const byte heatpumpOff         = 0;
 const byte heatpumpNormal      = 1;
 const byte heatpumpMaintenance = 2;
 
-Button relay1 = Button(11,PULLUP); // Heatpump ON-OFF state
-Button relay2 = Button(12,PULLUP); // FP mode (maintenance heating at 8 degrees C) ON-OFF state
+Button relay1 = Button(11, INPUT_PULLUP); // Heatpump ON-OFF state
+Button relay2 = Button(12, INPUT_PULLUP); // FP mode (maintenance heating at 8 degrees C) ON-OFF state
 
 IRSender irSender(9);              // IR led on Duemilanove digital pin 9
 

--- a/libraries/HeatpumpIR/examples/MySensorsNode/MySensorsNode.ino
+++ b/libraries/HeatpumpIR/examples/MySensorsNode/MySensorsNode.ino
@@ -1,3 +1,5 @@
+#include <Arduino.h>
+
 // HeatpumpIR libraries
 #include <FujitsuHeatpumpIR.h>
 #include <PanasonicCKPHeatpumpIR.h>
@@ -85,8 +87,7 @@ void loop()
 // Handle incoming messages from the MySensors Gateway
 void incomingMessage(const MyMessage &message) {
 
-	const char *irData;
-	long irCommand;
+  const char *irData;
 
   // V_IR type message
   if (message.type==V_IR_SEND) {
@@ -156,10 +157,10 @@ libraries\HeatpumpIR\HeatpumpIR.h for the constants
   byte fan   = (irCommand & 0x00000F00) >> 8;
   byte temp  = (irCommand & 0x000000FF);
 
-  prog_char* buf;
+  const char* buf;
   Serial.print(F("Model: "));
 
-  buf = (prog_char*)heatpumpIR[model]->model();
+  buf = heatpumpIR[model]->model();
   // 'model' is a PROGMEM pointer, so need to write a byte at a time
   while (char modelChar = pgm_read_byte(buf++))
   {
@@ -188,14 +189,14 @@ libraries\HeatpumpIR\HeatpumpIR.h for the constants
 
     if (model == 0) {
       Serial.println(F("Scheduling timer cancellation on Panasonic CKP heatpump..."));
-      panasonicCKPTimer = timer.after(120000, panasonicCancelTimer, (void *)NULL); // Called after 2 minutes
+      panasonicCKPTimer = timer.after(120000, panasonicCancelTimer); // Called after 2 minutes
     }
   }
 }
 
 
 // Cancel the timer on the Panasonic CKP heatpump
-void panasonicCancelTimer(void *context)
+void panasonicCancelTimer()
 {
   PanasonicCKPHeatpumpIR *panasonicCKPHeatpumpIR = new PanasonicCKPHeatpumpIR();
 

--- a/libraries/HeatpumpIR/examples/PanasonicCKPTimer/PanasonicCKPTimer.ino
+++ b/libraries/HeatpumpIR/examples/PanasonicCKPTimer/PanasonicCKPTimer.ino
@@ -1,5 +1,7 @@
+#include <Arduino.h>
+
 #include <PanasonicCKPHeatpumpIR.h>
-#include <Timer.h>
+#include <Timer.h> // https://github.com/JChristensen/Timer
 
 /*
     This schema demonstrates how to control the Panasonic CKP power state change. The CKP does not have discrete
@@ -34,8 +36,8 @@ void setup()
   heatpumpIR->send(irSender, POWER_ON, MODE_HEAT, FAN_2, 24, VDIR_UP, HDIR_AUTO);
   Serial.println("The heatpump should have beeped, and the TIMER led should be ON");
 
-  timer.after(60000, panasonicIsOn, NULL); // Called after 1 minute
-  timer.after(120000, panasonicCancelTimer, NULL); // Called after 2 minutes
+  timer.after(60000, panasonicIsOn); // Called after 1 minute
+  timer.after(120000, panasonicCancelTimer); // Called after 2 minutes
 
 }
 
@@ -44,12 +46,12 @@ void loop()
   timer.update();
 }
 
-void panasonicIsOn(void *context)
+void panasonicIsOn()
 {
   Serial.println("The heatpump should should turn ON by now, the TIMER led is still ON");
 }
 
-void panasonicCancelTimer(void *context)
+void panasonicCancelTimer()
 {
   heatpumpIR->sendPanasonicCKPCancelTimer(irSender);
   Serial.println("The TIMER led should now be OFF");

--- a/libraries/HeatpumpIR/examples/simple/simple.ino
+++ b/libraries/HeatpumpIR/examples/simple/simple.ino
@@ -1,3 +1,5 @@
+#include <Arduino.h>
+
 #include <FujitsuHeatpumpIR.h>
 #include <PanasonicCKPHeatpumpIR.h>
 #include <PanasonicHeatpumpIR.h>
@@ -25,13 +27,13 @@ void setup()
 void loop()
 {
   int i = 0;
-  prog_char* buf;
+  const char* buf;
 
   do {
     // Send the same IR command to all supported heatpumps
     Serial.print(F("Sending IR to "));
 
-    buf = (prog_char*)heatpumpIR[i]->model();
+    buf = heatpumpIR[i]->model();
     // 'model' is a PROGMEM pointer, so need to write a byte at a time
     while (char modelChar = pgm_read_byte(buf++))
     {
@@ -39,7 +41,7 @@ void loop()
     }
     Serial.print(F(", info: "));
 
-    buf = (prog_char*)heatpumpIR[i]->info();
+    buf = heatpumpIR[i]->info();
     // 'info' is a PROGMEM pointer, so need to write a byte at a time
     while (char infoChar = pgm_read_byte(buf++))
     {

--- a/libraries/MySensors/examples/HeatpumpIRController/HeatpumpIRController.ino
+++ b/libraries/MySensors/examples/HeatpumpIRController/HeatpumpIRController.ino
@@ -1,3 +1,5 @@
+#include <Arduino.h>
+
 // HeatpumpIR libraries, https://github.com/ToniA/arduino-heatpumpir
 #include <FujitsuHeatpumpIR.h>
 #include <PanasonicCKPHeatpumpIR.h>


### PR DESCRIPTION
The previous version used the '__PROG_TYPES_COMPAT__' definition. Now the library natively supports the Arduino IDE 1.6-style PROGMEM.