### PR TITLE
Debug output fixes for ESP8266

### DIFF
--- a/libraries/MySensors/utility/RF24.cpp
+++ b/libraries/MySensors/utility/RF24.cpp
@@ -287,59 +287,61 @@ uint8_t RF24::get_status(void)
 
 /****************************************************************************/
 #if !defined (MINIMAL)
+void RF24::print_hex( uint8_t v )
+{
+  Serial.print(v >> 4, HEX);
+  Serial.print(v & 0x0F, HEX);
+} 
+
 void RF24::print_status(uint8_t status)
 {
-  printf_P(PSTR("STATUS\t\t = 0x%02x RX_DR=%x TX_DS=%x MAX_RT=%x RX_P_NO=%x TX_FULL=%x\r\n"),
-           status,
-           (status & _BV(RX_DR))?1:0,
-           (status & _BV(TX_DS))?1:0,
-           (status & _BV(MAX_RT))?1:0,
-           ((status >> RX_P_NO) & B111),
-           (status & _BV(TX_FULL))?1:0
-          );
+  Serial.print(F("0x")); print_hex(status);
+  Serial.print(F(" RX_DR=")); Serial.print((status & _BV(RX_DR))?uint8_t(1):uint8_t(0));
+  Serial.print(F(" TX_DS=")); Serial.print((status & _BV(TX_DS))?uint8_t(1):uint8_t(0));
+  Serial.print(F(" MAX_RT=")); Serial.print((status & _BV(MAX_RT))?uint8_t(1):uint8_t(0));
+  Serial.print(F(" RX_P_NO=")); Serial.print((status >> RX_P_NO) & uint8_t(B111));
+  Serial.print(F(" TX_FULL=")); Serial.println((status & _BV(TX_FULL))?uint8_t(1):uint8_t(0));
 }
 
 /****************************************************************************/
 
 void RF24::print_observe_tx(uint8_t value)
 {
-  printf_P(PSTR("OBSERVE_TX=%02x: POLS_CNT=%x ARC_CNT=%x\r\n"),
-           value,
-           (value >> PLOS_CNT) & B1111,
-           (value >> ARC_CNT) & B1111
-          );
+  Serial.print(F("0x")); print_hex(value);
+  Serial.print(F(": POLS_CNT=")); Serial.print((value >> PLOS_CNT) & uint8_t(B1111));
+  Serial.print(F(" ARC_CNT=")); Serial.println((value >> ARC_CNT) & uint8_t(B1111));
 }
 
 /****************************************************************************/
 
-void RF24::print_byte_register(const char* name, uint8_t reg, uint8_t qty)
+void RF24::print_byte_register(uint8_t reg, uint8_t qty)
 {
-  char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
-  printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
+  Serial.print(F("0x")); 
   while (qty--)
-    printf_P(PSTR(" 0x%02x"),read_register(reg++));
-  printf_P(PSTR("\r\n"));
+  {
+    print_hex(read_register(reg++));
+    Serial.print(F(" ")); 
+  }
+  Serial.println(F(""));
 }
 
 /****************************************************************************/
-
-void RF24::print_address_register(const char* name, uint8_t reg, uint8_t qty)
+void RF24::print_address_register(uint8_t reg, uint8_t qty)
 {
-  char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
-  printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
-
+  Serial.print(F("0x"));
   while (qty--)
   {
     uint8_t buffer[addr_width];
     read_register(reg++,buffer,sizeof buffer);
 
-    printf_P(PSTR(" 0x"));
     uint8_t* bufptr = buffer + sizeof buffer;
     while( --bufptr >= buffer )
-      printf_P(PSTR("%02x"),*bufptr);
+    {
+      print_hex(read_register(*bufptr));
+    }
+    Serial.print(F(" "));
   }
-
-  printf_P(PSTR("\r\n"));
+  Serial.println(F(""));
 }
 #endif
 /****************************************************************************/
@@ -375,7 +377,6 @@ uint8_t RF24::getPayloadSize(void)
 /****************************************************************************/
 
 #if !defined (MINIMAL)
-
 static const char rf24_datarate_e_str_0[] PROGMEM = "1MBPS";
 static const char rf24_datarate_e_str_1[] PROGMEM = "2MBPS";
 static const char rf24_datarate_e_str_2[] PROGMEM = "250KBPS";
@@ -409,34 +410,35 @@ static const char * const rf24_pa_dbm_e_str_P[] PROGMEM = {
   rf24_pa_dbm_e_str_3,
 };
 
-void RF24::printDetails(void)
-{
-  print_status(get_status());
-
-  print_address_register(PSTR("RX_ADDR_P0-1"),RX_ADDR_P0,2);
-  print_byte_register(PSTR("RX_ADDR_P2-5"),RX_ADDR_P2,4);
-  print_address_register(PSTR("TX_ADDR"),TX_ADDR);
-
-  print_byte_register(PSTR("RX_PW_P0-6"),RX_PW_P0,6);
-  print_byte_register(PSTR("EN_AA"),EN_AA);
-  print_byte_register(PSTR("EN_RXADDR"),EN_RXADDR);
-  print_byte_register(PSTR("RF_CH"),RF_CH);
-  print_byte_register(PSTR("RF_SETUP"),RF_SETUP);
-  print_byte_register(PSTR("CONFIG"),CONFIG);
-  print_byte_register(PSTR("DYNPD/FEATURE"),DYNPD,2);
-
-#if defined(__arm__)
-  printf_P(PSTR("Data Rate\t = %s\r\n"),pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
-  printf_P(PSTR("Model\t\t = %s\r\n"),pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
-  printf_P(PSTR("CRC Length\t = %s\r\n"),pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
-  printf_P(PSTR("PA Power\t = %s\r\n"),pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
+#if (INTPTR_MAX == INT16_MAX)
+// 16-bit architecture -> read word from flash and cast to ptr
+#define PGM_READ_PTR(adr)  (reinterpret_cast<__FlashStringHelper*>(pgm_read_word(adr)))
+#elif (INTPTR_MAX == INT32_MAX)
+// 32-bit architecture -> read double-word from flash and cast to ptr
+#define PGM_READ_PTR(adr)  (reinterpret_cast<__FlashStringHelper*>(pgm_read_dword(adr)))
 #else
-  printf_P(PSTR("Data Rate\t = %S\r\n"),pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
-  printf_P(PSTR("Model\t\t = %S\r\n"),pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
-  printf_P(PSTR("CRC Length\t = %S\r\n"),pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
-  printf_P(PSTR("PA Power\t = %S\r\n"),pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
+#error Unsupported processor architecture!
 #endif
 
+void RF24::printDetails(void)
+{
+  Serial.print(F("STATUS\t\t"));      print_status(get_status());
+  Serial.print(F("RX_ADDR_P0-1\t"));  print_address_register(RX_ADDR_P0,2);
+  Serial.print(F("RX_ADDR_P2-5\t"));  print_byte_register(RX_ADDR_P2,4);
+  Serial.print(F("TX_ADDR\t\t"));     print_address_register(TX_ADDR);
+
+  Serial.print(F("RX_PW_P0-6\t"));    print_byte_register(RX_PW_P0,6);
+  Serial.print(F("EN_AA\t\t"));       print_byte_register(EN_AA);
+  Serial.print(F("EN_RXADDR\t"));     print_byte_register(EN_RXADDR);
+  Serial.print(F("RF_CH\t\t"));       print_byte_register(RF_CH);
+  Serial.print(F("RF_SETUP\t"));      print_byte_register(RF_SETUP);
+  Serial.print(F("CONFIG\t\t"));      print_byte_register(CONFIG);
+  Serial.print(F("DYNPD/FEATURE\t")); print_byte_register(DYNPD,2);
+
+  Serial.print(F("Data Rate\t"));     Serial.println(PGM_READ_PTR(&rf24_datarate_e_str_P[getDataRate()]));
+  Serial.print(F("Model\t\t"));       Serial.println(PGM_READ_PTR(&rf24_model_e_str_P[isPVariant()]));
+  Serial.print(F("CRC Length\t"));    Serial.println(PGM_READ_PTR(&rf24_crclength_e_str_P[getCRCLength()]));
+  Serial.print(F("PA Power\t"));      Serial.println(PGM_READ_PTR(&rf24_pa_dbm_e_str_P[getPALevel()]));
 }
 
 #endif

--- a/libraries/MySensors/utility/RF24.h
+++ b/libraries/MySensors/utility/RF24.h
@@ -923,7 +923,7 @@ private:
    */
   uint8_t get_status(void);
 
-  #if !defined (MINIMAL)
+#ifdef DEBUG
   /**
    * Decode and print the given status to stdout
    *
@@ -973,7 +973,7 @@ private:
    *
    * @param v  Value to print in hex.
    */
-  void print_hex( uint8_t v );
+  void print_hex( uint8_t v, const bool prefix0x = false );
   
 #endif
   /**

--- a/libraries/MySensors/utility/RF24.h
+++ b/libraries/MySensors/utility/RF24.h
@@ -943,30 +943,38 @@ private:
   void print_observe_tx(uint8_t value);
 
   /**
-   * Print the name and value of an 8-bit register to stdout
+   * Print the value of an 8-bit register to stdout
    *
    * Optionally it can print some quantity of successive
    * registers on the same line.  This is useful for printing a group
    * of related registers on one line.
    *
-   * @param name Name of the register
    * @param reg Which register. Use constants from nRF24L01.h
    * @param qty How many successive registers to print
    */
-  void print_byte_register(const char* name, uint8_t reg, uint8_t qty = 1);
+  void print_byte_register(uint8_t reg, uint8_t qty = 1);
 
   /**
-   * Print the name and value of a 40-bit address register to stdout
+   * Print the value of a 40-bit address register to stdout
    *
    * Optionally it can print some quantity of successive
    * registers on the same line.  This is useful for printing a group
    * of related registers on one line.
    *
-   * @param name Name of the register
    * @param reg Which register. Use constants from nRF24L01.h
    * @param qty How many successive registers to print
    */
-  void print_address_register(const char* name, uint8_t reg, uint8_t qty = 1);
+  void print_address_register(uint8_t reg, uint8_t qty = 1);
+
+  /**
+   * Print a value in hex to serial output.
+   *
+   * For values < 16 a leading 0 will be printed.
+   *
+   * @param v  Value to print in hex.
+   */
+  void print_hex( uint8_t v );
+  
 #endif
   /**
    * Turn on or off the special features of the chip

--- a/libraries/MySensors/utility/RF24_config.h
+++ b/libraries/MySensors/utility/RF24_config.h
@@ -24,7 +24,7 @@
   /*** USER DEFINES:  ***/  
   //#define FAILURE_HANDLING
   //#define SERIAL_DEBUG  
-  #define MINIMAL
+  //#define MINIMAL
   //#define SPI_UART  // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
   //#define SOFTSPI   // Requires library from https://github.com/greiman/DigitalIO
   /**********************/
@@ -99,7 +99,6 @@
 // Arduino DUE is arm and does not include avr/pgmspace
 #if defined(__AVR__)
 	#include <avr/pgmspace.h>
-	#define PRIPSTR "%S"
 #else
 #if defined(ESP8266)
 #include <pgmspace.h>
@@ -119,9 +118,6 @@
 	#define PROGMEM
 	#define pgm_read_word(p) (*(p))
 #endif
-
-	#define PRIPSTR "%s"
-
 #endif
 
 

--- a/libraries/MySensors/utility/RF24_config.h
+++ b/libraries/MySensors/utility/RF24_config.h
@@ -23,8 +23,6 @@
 
   /*** USER DEFINES:  ***/  
   //#define FAILURE_HANDLING
-  //#define SERIAL_DEBUG  
-  //#define MINIMAL
   //#define SPI_UART  // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
   //#define SOFTSPI   // Requires library from https://github.com/greiman/DigitalIO
   /**********************/
@@ -74,16 +72,7 @@
   #define _SPI SPI
 #endif
 
-  
-  #ifdef SERIAL_DEBUG
-	#define IF_SERIAL_DEBUG(x) ({x;})
-  #else
-	#define IF_SERIAL_DEBUG(x)
-	#if defined(RF24_TINY)
-	#define printf_P(...)
-    #endif
-  #endif
-
+ 
 // Avoid spurious warnings
 // Arduino DUE is arm and uses traditional PROGMEM constructs
 #if 1


### PR DESCRIPTION
Fixed printDetails() to work for ESP8266.
Replaced printf_P calls by Serial.print, as printf_P tends to crash on ESP8266.
Simplified debugging of driver by only #defining DEBUG (removed MINIMAL & SERIAL_DEBUG).