### PR TITLE
Fix printDetails() & debugging for ESP8266

### DIFF
--- a/libraries/MySensors/MyConfig.h
+++ b/libraries/MySensors/MyConfig.h
@@ -26,6 +26,10 @@
 // to see what is actually is happening when developing
 #define DEBUG
 
+// Enable MY_DEBUG_VERBOSE flag for verbose debug prints. Requires DEBUG to be enabled.
+// This will add even more to the size of the final sketch!
+//#define MY_DEBUG_VERBOSE
+
 // Disable this line, If you are using TX(1), RX(0) as normal I/O pin
 #define ENABLED_SERIAL
 
@@ -144,6 +148,5 @@
 // Enable this for encryption of packets
 //#define RFM69_ENABLE_ENCRYPTION
 #define RFM69_ENCRYPTKEY    "sampleEncryptKey" //exactly the same 16 characters/bytes on all nodes!
-
 
 #endif

--- a/libraries/MySensors/utility/RF24.cpp
+++ b/libraries/MySensors/utility/RF24.cpp
@@ -10,7 +10,18 @@
 #include "RF24_config.h"
 #include "RF24.h"
 
+// Save some bytes by reusing strings.
+static const char space_str_P[] PROGMEM   = " ";
+
 /****************************************************************************/
+static void print_hex( uint8_t v, const bool prefix0x = false )
+{
+  if (prefix0x)
+    Serial.print(F("0x"));
+  
+  Serial.print(v >> 4, HEX);
+  Serial.print(v & 0x0F, HEX);
+}
 
 void RF24::csn(bool mode)
 {
@@ -286,52 +297,61 @@ uint8_t RF24::get_status(void)
 }
 
 /****************************************************************************/
+void RF24::print_feature(void)
+{
 #ifdef DEBUG
-void RF24::print_hex( uint8_t v, const bool prefix0x )
-{
-  if (prefix0x)
-    Serial.print(F("0x"));
-  
-  Serial.print(v >> 4, HEX);
-  Serial.print(v & 0x0F, HEX);
-} 
+  Serial.print(F("FEATURE="));
+  print_hex(read_register(FEATURE), true);
+  Serial.println(space_str_P); 
+#endif
+}
 
-void RF24::print_status(uint8_t status)
+/****************************************************************************/
+void RF24::print_status(uint8_t status) const
 {
+#ifdef MY_DEBUG_VERBOSE
+  const uint8_t one  = uint8_t(1);
+  const uint8_t zero = uint8_t(0);
   print_hex(status, true);
-  Serial.print(F(" RX_DR=")); Serial.print((status & _BV(RX_DR))?uint8_t(1):uint8_t(0));
-  Serial.print(F(" TX_DS=")); Serial.print((status & _BV(TX_DS))?uint8_t(1):uint8_t(0));
-  Serial.print(F(" MAX_RT=")); Serial.print((status & _BV(MAX_RT))?uint8_t(1):uint8_t(0));
+  Serial.print(F(" RX_DR="));   Serial.print((status & _BV(RX_DR))     ? one : zero );
+  Serial.print(F(" TX_DS="));   Serial.print((status & _BV(TX_DS))     ? one : zero );
+  Serial.print(F(" MAX_RT="));  Serial.print((status & _BV(MAX_RT))    ? one : zero );
   Serial.print(F(" RX_P_NO=")); Serial.print((status >> RX_P_NO) & uint8_t(B111));
-  Serial.print(F(" TX_FULL=")); Serial.println((status & _BV(TX_FULL))?uint8_t(1):uint8_t(0));
+  Serial.print(F(" TX_FULL=")); Serial.println((status & _BV(TX_FULL)) ? one : zero );
+#endif
 }
 
 /****************************************************************************/
 
-void RF24::print_observe_tx(uint8_t value)
+void RF24::print_observe_tx(uint8_t value) const
 {
+#ifdef MY_DEBUG_VERBOSE
   print_hex(value, true);
-  Serial.print(F(": POLS_CNT=")); Serial.print((value >> PLOS_CNT) & uint8_t(B1111));
-  Serial.print(F(" ARC_CNT=")); Serial.println((value >> ARC_CNT) & uint8_t(B1111));
+  Serial.print(F(": POLS_CNT=")); Serial.print((value >> PLOS_CNT)   & uint8_t(B1111));
+  Serial.print(F(" ARC_CNT="));   Serial.println((value >> ARC_CNT)  & uint8_t(B1111));
+#endif
 }
 
 /****************************************************************************/
 
 void RF24::print_byte_register(uint8_t reg, uint8_t qty)
 {
+#ifdef MY_DEBUG_VERBOSE
   bool prefix0x = true;
   while (qty--)
   {
     print_hex(read_register(reg++), prefix0x);
-    Serial.print(F(" ")); 
+    Serial.print(space_str_P); 
     prefix0x = false;
   }
-  Serial.println(F(""));
+  Serial.println(space_str_P);
+#endif
 }
 
 /****************************************************************************/
 void RF24::print_address_register(uint8_t reg, uint8_t qty)
 {
+#ifdef MY_DEBUG_VERBOSE
   bool prefix0x = true;
   while (qty--)
   {
@@ -344,11 +364,11 @@ void RF24::print_address_register(uint8_t reg, uint8_t qty)
       print_hex(read_register(*bufptr), prefix0x);
       prefix0x = false;
     }
-    Serial.print(F(" "));
+    Serial.print(space_str_P);
   }
-  Serial.println(F(""));
-}
+  Serial.println(space_str_P);
 #endif
+}
 /****************************************************************************/
 
 RF24::RF24(uint8_t _cepin, uint8_t _cspin):
@@ -380,8 +400,7 @@ uint8_t RF24::getPayloadSize(void)
 }
 
 /****************************************************************************/
-
-#ifdef DEBUG
+#ifdef MY_DEBUG_VERBOSE
 static const char rf24_datarate_e_str_0[] PROGMEM = "1MBPS";
 static const char rf24_datarate_e_str_1[] PROGMEM = "2MBPS";
 static const char rf24_datarate_e_str_2[] PROGMEM = "250KBPS";
@@ -414,6 +433,7 @@ static const char * const rf24_pa_dbm_e_str_P[] PROGMEM = {
   rf24_pa_dbm_e_str_2,
   rf24_pa_dbm_e_str_3,
 };
+#endif
 
 #if (INTPTR_MAX == INT16_MAX)
 // 16-bit architecture -> read word from flash and cast to ptr
@@ -427,6 +447,7 @@ static const char * const rf24_pa_dbm_e_str_P[] PROGMEM = {
 
 void RF24::printDetails(void)
 {
+#ifdef MY_DEBUG_VERBOSE
   Serial.print(F("STATUS\t\t"));      print_status(get_status());
   Serial.print(F("RX_ADDR_P0-1\t"));  print_address_register(RX_ADDR_P0,2);
   Serial.print(F("RX_ADDR_P2-5\t"));  print_byte_register(RX_ADDR_P2,4);
@@ -444,8 +465,8 @@ void RF24::printDetails(void)
   Serial.print(F("Model\t\t"));       Serial.println(PGM_READ_PTR(&rf24_model_e_str_P[isPVariant()]));
   Serial.print(F("CRC Length\t"));    Serial.println(PGM_READ_PTR(&rf24_crclength_e_str_P[getCRCLength()]));
   Serial.print(F("PA Power\t"));      Serial.println(PGM_READ_PTR(&rf24_pa_dbm_e_str_P[getPALevel()]));
-}
 #endif
+}
 /****************************************************************************/
 
 void RF24::begin(void)
@@ -521,10 +542,8 @@ void RF24::begin(void)
   // PTX should use only 22uA of power
   write_register(CONFIG, ( read_register(CONFIG) ) & ~_BV(PRIM_RX) );
 
-#ifdef DEBUG
   // Dump register values
   printDetails();
-#endif
 }
 
 /****************************************************************************/
@@ -1062,16 +1081,13 @@ void RF24::toggle_features(void)
 }
 
 /****************************************************************************/
-
 void RF24::enableDynamicPayloads(void)
 {
   // Enable dynamic payload throughout the system
   toggle_features();
   write_register(FEATURE,read_register(FEATURE) | _BV(EN_DPL) );
+  print_feature();
 
-#ifdef DEBUG
-  Serial.print(F("FEATURE=")); print_hex(read_register(FEATURE), true); Serial.println(F("")); 
-#endif
   // Enable dynamic payload on all pipes
   //
   // Not sure the use case of only having dynamic payload on certain
@@ -1090,10 +1106,8 @@ void RF24::enableAckPayload(void)
   //
   toggle_features();
   write_register(FEATURE,read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
+  print_feature();
 
-#ifdef DEBUG
-  Serial.print(F("FEATURE=")); print_hex(read_register(FEATURE), true); Serial.println(F("")); 
-#endif
   //
   // Enable dynamic payload on pipes 0 & 1
   //
@@ -1108,12 +1122,9 @@ void RF24::enableDynamicAck(void){
   //
   // enable dynamic ack features
   //
-    toggle_features();
-    write_register(FEATURE,read_register(FEATURE) | _BV(EN_DYN_ACK) );
-
-#ifdef DEBUG
-    Serial.print(F("FEATURE=")); print_hex(read_register(FEATURE), true); Serial.println(F("")); 
-#endif
+  toggle_features();
+  write_register(FEATURE,read_register(FEATURE) | _BV(EN_DYN_ACK) );
+  print_feature();
 }
 
 /****************************************************************************/

--- a/libraries/MySensors/utility/RF24.cpp
+++ b/libraries/MySensors/utility/RF24.cpp
@@ -132,19 +132,19 @@ uint8_t RF24::write_register(uint8_t reg, uint8_t value)
 {
   uint8_t status;
 
-  IF_SERIAL_DEBUG(printf_P(PSTR("write_register(%02x,%02x)\r\n"),reg,value));
+#ifdef DEBUG
+  Serial.print(F("write_register(")); print_hex(reg, true); Serial.print(F(",")); print_hex(value, true); Serial.println(F(")")); 
+#endif
 
-  #if defined (__arm__) && !defined ( CORE_TEENSY )
+#if defined (__arm__) && !defined ( CORE_TEENSY )
   status = _SPI.transfer(csn_pin, W_REGISTER | ( REGISTER_MASK & reg ), SPI_CONTINUE);
   _SPI.transfer(csn_pin,value);
-  #else
-
+#else
   csn(LOW);
   status = _SPI.transfer( W_REGISTER | ( REGISTER_MASK & reg ) );
   _SPI.transfer(value);
   csn(HIGH);
-
-  #endif
+#endif
 
   return status;
 }
@@ -286,60 +286,67 @@ uint8_t RF24::get_status(void)
 }
 
 /****************************************************************************/
-#if !defined (MINIMAL)
+#ifdef DEBUG
+void RF24::print_hex( uint8_t v, const bool prefix0x )
+{
+  if (prefix0x)
+    Serial.print(F("0x"));
+  
+  Serial.print(v >> 4, HEX);
+  Serial.print(v & 0x0F, HEX);
+} 
+
 void RF24::print_status(uint8_t status)
 {
-  printf_P(PSTR("STATUS\t\t = 0x%02x RX_DR=%x TX_DS=%x MAX_RT=%x RX_P_NO=%x TX_FULL=%x\r\n"),
-           status,
-           (status & _BV(RX_DR))?1:0,
-           (status & _BV(TX_DS))?1:0,
-           (status & _BV(MAX_RT))?1:0,
-           ((status >> RX_P_NO) & B111),
-           (status & _BV(TX_FULL))?1:0
-          );
+  print_hex(status, true);
+  Serial.print(F(" RX_DR=")); Serial.print((status & _BV(RX_DR))?uint8_t(1):uint8_t(0));
+  Serial.print(F(" TX_DS=")); Serial.print((status & _BV(TX_DS))?uint8_t(1):uint8_t(0));
+  Serial.print(F(" MAX_RT=")); Serial.print((status & _BV(MAX_RT))?uint8_t(1):uint8_t(0));
+  Serial.print(F(" RX_P_NO=")); Serial.print((status >> RX_P_NO) & uint8_t(B111));
+  Serial.print(F(" TX_FULL=")); Serial.println((status & _BV(TX_FULL))?uint8_t(1):uint8_t(0));
 }
 
 /****************************************************************************/
 
 void RF24::print_observe_tx(uint8_t value)
 {
-  printf_P(PSTR("OBSERVE_TX=%02x: POLS_CNT=%x ARC_CNT=%x\r\n"),
-           value,
-           (value >> PLOS_CNT) & B1111,
-           (value >> ARC_CNT) & B1111
-          );
+  print_hex(value, true);
+  Serial.print(F(": POLS_CNT=")); Serial.print((value >> PLOS_CNT) & uint8_t(B1111));
+  Serial.print(F(" ARC_CNT=")); Serial.println((value >> ARC_CNT) & uint8_t(B1111));
 }
 
 /****************************************************************************/
 
-void RF24::print_byte_register(const char* name, uint8_t reg, uint8_t qty)
+void RF24::print_byte_register(uint8_t reg, uint8_t qty)
 {
-  char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
-  printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
+  bool prefix0x = true;
   while (qty--)
-    printf_P(PSTR(" 0x%02x"),read_register(reg++));
-  printf_P(PSTR("\r\n"));
+  {
+    print_hex(read_register(reg++), prefix0x);
+    Serial.print(F(" ")); 
+    prefix0x = false;
+  }
+  Serial.println(F(""));
 }
 
 /****************************************************************************/
-
-void RF24::print_address_register(const char* name, uint8_t reg, uint8_t qty)
+void RF24::print_address_register(uint8_t reg, uint8_t qty)
 {
-  char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
-  printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
-
+  bool prefix0x = true;
   while (qty--)
   {
     uint8_t buffer[addr_width];
     read_register(reg++,buffer,sizeof buffer);
 
-    printf_P(PSTR(" 0x"));
     uint8_t* bufptr = buffer + sizeof buffer;
     while( --bufptr >= buffer )
-      printf_P(PSTR("%02x"),*bufptr);
+    {
+      print_hex(read_register(*bufptr), prefix0x);
+      prefix0x = false;
+    }
+    Serial.print(F(" "));
   }
-
-  printf_P(PSTR("\r\n"));
+  Serial.println(F(""));
 }
 #endif
 /****************************************************************************/
@@ -374,8 +381,7 @@ uint8_t RF24::getPayloadSize(void)
 
 /****************************************************************************/
 
-#if !defined (MINIMAL)
-
+#ifdef DEBUG
 static const char rf24_datarate_e_str_0[] PROGMEM = "1MBPS";
 static const char rf24_datarate_e_str_1[] PROGMEM = "2MBPS";
 static const char rf24_datarate_e_str_2[] PROGMEM = "250KBPS";
@@ -409,36 +415,36 @@ static const char * const rf24_pa_dbm_e_str_P[] PROGMEM = {
   rf24_pa_dbm_e_str_3,
 };
 
-void RF24::printDetails(void)
-{
-  print_status(get_status());
-
-  print_address_register(PSTR("RX_ADDR_P0-1"),RX_ADDR_P0,2);
-  print_byte_register(PSTR("RX_ADDR_P2-5"),RX_ADDR_P2,4);
-  print_address_register(PSTR("TX_ADDR"),TX_ADDR);
-
-  print_byte_register(PSTR("RX_PW_P0-6"),RX_PW_P0,6);
-  print_byte_register(PSTR("EN_AA"),EN_AA);
-  print_byte_register(PSTR("EN_RXADDR"),EN_RXADDR);
-  print_byte_register(PSTR("RF_CH"),RF_CH);
-  print_byte_register(PSTR("RF_SETUP"),RF_SETUP);
-  print_byte_register(PSTR("CONFIG"),CONFIG);
-  print_byte_register(PSTR("DYNPD/FEATURE"),DYNPD,2);
-
-#if defined(__arm__)
-  printf_P(PSTR("Data Rate\t = %s\r\n"),pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
-  printf_P(PSTR("Model\t\t = %s\r\n"),pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
-  printf_P(PSTR("CRC Length\t = %s\r\n"),pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
-  printf_P(PSTR("PA Power\t = %s\r\n"),pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
+#if (INTPTR_MAX == INT16_MAX)
+// 16-bit architecture -> read word from flash and cast to ptr
+#define PGM_READ_PTR(adr)  (reinterpret_cast<__FlashStringHelper*>(pgm_read_word(adr)))
+#elif (INTPTR_MAX == INT32_MAX)
+// 32-bit architecture -> read double-word from flash and cast to ptr
+#define PGM_READ_PTR(adr)  (reinterpret_cast<__FlashStringHelper*>(pgm_read_dword(adr)))
 #else
-  printf_P(PSTR("Data Rate\t = %S\r\n"),pgm_read_word(&rf24_datarate_e_str_P[getDataRate()]));
-  printf_P(PSTR("Model\t\t = %S\r\n"),pgm_read_word(&rf24_model_e_str_P[isPVariant()]));
-  printf_P(PSTR("CRC Length\t = %S\r\n"),pgm_read_word(&rf24_crclength_e_str_P[getCRCLength()]));
-  printf_P(PSTR("PA Power\t = %S\r\n"),pgm_read_word(&rf24_pa_dbm_e_str_P[getPALevel()]));
+#error Unsupported processor architecture!
 #endif
 
-}
+void RF24::printDetails(void)
+{
+  Serial.print(F("STATUS\t\t"));      print_status(get_status());
+  Serial.print(F("RX_ADDR_P0-1\t"));  print_address_register(RX_ADDR_P0,2);
+  Serial.print(F("RX_ADDR_P2-5\t"));  print_byte_register(RX_ADDR_P2,4);
+  Serial.print(F("TX_ADDR\t\t"));     print_address_register(TX_ADDR);
 
+  Serial.print(F("RX_PW_P0-6\t"));    print_byte_register(RX_PW_P0,6);
+  Serial.print(F("EN_AA\t\t"));       print_byte_register(EN_AA);
+  Serial.print(F("EN_RXADDR\t"));     print_byte_register(EN_RXADDR);
+  Serial.print(F("RF_CH\t\t"));       print_byte_register(RF_CH);
+  Serial.print(F("RF_SETUP\t"));      print_byte_register(RF_SETUP);
+  Serial.print(F("CONFIG\t\t"));      print_byte_register(CONFIG);
+  Serial.print(F("DYNPD/FEATURE\t")); print_byte_register(DYNPD,2);
+
+  Serial.print(F("Data Rate\t"));     Serial.println(PGM_READ_PTR(&rf24_datarate_e_str_P[getDataRate()]));
+  Serial.print(F("Model\t\t"));       Serial.println(PGM_READ_PTR(&rf24_model_e_str_P[isPVariant()]));
+  Serial.print(F("CRC Length\t"));    Serial.println(PGM_READ_PTR(&rf24_crclength_e_str_P[getCRCLength()]));
+  Serial.print(F("PA Power\t"));      Serial.println(PGM_READ_PTR(&rf24_pa_dbm_e_str_P[getPALevel()]));
+}
 #endif
 /****************************************************************************/
 
@@ -515,6 +521,10 @@ void RF24::begin(void)
   // PTX should use only 22uA of power
   write_register(CONFIG, ( read_register(CONFIG) ) & ~_BV(PRIM_RX) );
 
+#ifdef DEBUG
+  // Dump register values
+  printDetails();
+#endif
 }
 
 /****************************************************************************/
@@ -528,21 +538,20 @@ void RF24::startListening(void)
   write_register(RF24_STATUS, _BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT) );
 
   // Restore the pipe0 adddress, if exists
-  if (pipe0_reading_address[0] > 0){
-    write_register(RX_ADDR_P0, pipe0_reading_address, addr_width);	
-  }else{
-	closeReadingPipe(0);
+  if (pipe0_reading_address[0] > 0) {
+    write_register(RX_ADDR_P0, pipe0_reading_address, addr_width);
+  } else {
+    closeReadingPipe(0);
   }
 
   // Flush buffers
   //flush_rx();
-  if(read_register(FEATURE) & _BV(EN_ACK_PAY)){
-	flush_tx();
+  if(read_register(FEATURE) & _BV(EN_ACK_PAY)) {
+    flush_tx();
   }
 
   // Go!
   ce(HIGH);
- 
 }
 
 /****************************************************************************/
@@ -566,13 +575,13 @@ static uint8_t get_child_pipe_mask(const uint8_t idx)
 void RF24::stopListening(void)
 {
   ce(LOW);
-  #if defined(__arm__)
-  	delayMicroseconds(300);
-  #endif
+#if defined(__arm__)
+  delayMicroseconds(300);
+#endif
   delayMicroseconds(130);
 
-  if(read_register(FEATURE) & _BV(EN_ACK_PAY)){
-	flush_tx();
+  if(read_register(FEATURE) & _BV(EN_ACK_PAY)) {
+    flush_tx();
   }
 
   //flush_rx();
@@ -621,8 +630,10 @@ void RF24::powerUp(void)
 /******************************************************************/
 #if defined (FAILURE_HANDLING)
 void RF24::errNotify(){
-	IF_SERIAL_DEBUG(printf_P(PSTR("HARDWARE FAIL\r\n")));
-	failureDetected = 1;
+#ifdef DEBUG
+  Serial.println(F("HARDWARE FAIL"));
+#endif
+  failureDetected = 1;
 }
 #endif
 /******************************************************************/
@@ -1055,13 +1066,12 @@ void RF24::toggle_features(void)
 void RF24::enableDynamicPayloads(void)
 {
   // Enable dynamic payload throughout the system
+  toggle_features();
+  write_register(FEATURE,read_register(FEATURE) | _BV(EN_DPL) );
 
-    toggle_features();
-    write_register(FEATURE,read_register(FEATURE) | _BV(EN_DPL) );
-
-
-  IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n",read_register(FEATURE)));
-
+#ifdef DEBUG
+  Serial.print(F("FEATURE=")); print_hex(read_register(FEATURE), true); Serial.println(F("")); 
+#endif
   // Enable dynamic payload on all pipes
   //
   // Not sure the use case of only having dynamic payload on certain
@@ -1078,12 +1088,12 @@ void RF24::enableAckPayload(void)
   //
   // enable ack payload and dynamic payload features
   //
+  toggle_features();
+  write_register(FEATURE,read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
 
-    toggle_features();
-    write_register(FEATURE,read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL) );
-
-  IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n",read_register(FEATURE)));
-
+#ifdef DEBUG
+  Serial.print(F("FEATURE=")); print_hex(read_register(FEATURE), true); Serial.println(F("")); 
+#endif
   //
   // Enable dynamic payload on pipes 0 & 1
   //
@@ -1101,9 +1111,9 @@ void RF24::enableDynamicAck(void){
     toggle_features();
     write_register(FEATURE,read_register(FEATURE) | _BV(EN_DYN_ACK) );
 
-  IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n",read_register(FEATURE)));
-
-
+#ifdef DEBUG
+    Serial.print(F("FEATURE=")); print_hex(read_register(FEATURE), true); Serial.println(F("")); 
+#endif
 }
 
 /****************************************************************************/

--- a/libraries/MySensors/utility/RF24.cpp
+++ b/libraries/MySensors/utility/RF24.cpp
@@ -318,22 +318,24 @@ void RF24::print_status(uint8_t status) const
   Serial.print(F(" MAX_RT="));  Serial.print((status & _BV(MAX_RT))    ? one : zero );
   Serial.print(F(" RX_P_NO=")); Serial.print((status >> RX_P_NO) & uint8_t(B111));
   Serial.print(F(" TX_FULL=")); Serial.println((status & _BV(TX_FULL)) ? one : zero );
+#else
+  (void)status;
 #endif
 }
 
 /****************************************************************************/
-
 void RF24::print_observe_tx(uint8_t value) const
 {
 #ifdef MY_DEBUG_VERBOSE
   print_hex(value, true);
   Serial.print(F(": POLS_CNT=")); Serial.print((value >> PLOS_CNT)   & uint8_t(B1111));
   Serial.print(F(" ARC_CNT="));   Serial.println((value >> ARC_CNT)  & uint8_t(B1111));
+#else
+  (void)value;
 #endif
 }
 
 /****************************************************************************/
-
 void RF24::print_byte_register(uint8_t reg, uint8_t qty)
 {
 #ifdef MY_DEBUG_VERBOSE
@@ -345,6 +347,9 @@ void RF24::print_byte_register(uint8_t reg, uint8_t qty)
     prefix0x = false;
   }
   Serial.println(space_str_P);
+#else
+  (void)reg;
+  (void)qty;
 #endif
 }
 
@@ -367,6 +372,9 @@ void RF24::print_address_register(uint8_t reg, uint8_t qty)
     Serial.print(space_str_P);
   }
   Serial.println(space_str_P);
+#else
+  (void)reg;
+  (void)qty;
 #endif
 }
 /****************************************************************************/

--- a/libraries/MySensors/utility/RF24.h
+++ b/libraries/MySensors/utility/RF24.h
@@ -923,7 +923,7 @@ private:
    */
   uint8_t get_status(void);
 
-  #if !defined (MINIMAL)
+#ifdef DEBUG
   /**
    * Decode and print the given status to stdout
    *
@@ -943,30 +943,38 @@ private:
   void print_observe_tx(uint8_t value);
 
   /**
-   * Print the name and value of an 8-bit register to stdout
+   * Print the value of an 8-bit register to stdout
    *
    * Optionally it can print some quantity of successive
    * registers on the same line.  This is useful for printing a group
    * of related registers on one line.
    *
-   * @param name Name of the register
    * @param reg Which register. Use constants from nRF24L01.h
    * @param qty How many successive registers to print
    */
-  void print_byte_register(const char* name, uint8_t reg, uint8_t qty = 1);
+  void print_byte_register(uint8_t reg, uint8_t qty = 1);
 
   /**
-   * Print the name and value of a 40-bit address register to stdout
+   * Print the value of a 40-bit address register to stdout
    *
    * Optionally it can print some quantity of successive
    * registers on the same line.  This is useful for printing a group
    * of related registers on one line.
    *
-   * @param name Name of the register
    * @param reg Which register. Use constants from nRF24L01.h
    * @param qty How many successive registers to print
    */
-  void print_address_register(const char* name, uint8_t reg, uint8_t qty = 1);
+  void print_address_register(uint8_t reg, uint8_t qty = 1);
+
+  /**
+   * Print a value in hex to serial output.
+   *
+   * For values < 16 a leading 0 will be printed.
+   *
+   * @param v  Value to print in hex.
+   */
+  void print_hex( uint8_t v, const bool prefix0x = false );
+  
 #endif
   /**
    * Turn on or off the special features of the chip

--- a/libraries/MySensors/utility/RF24.h
+++ b/libraries/MySensors/utility/RF24.h
@@ -210,9 +210,9 @@ public:
   /**@{*/
 
   /**
-   * Print a giant block of debugging information to stdout
+   * Print a giant block of debugging information to serial
    *
-   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
+   * @warning Does nothing if MY_DEBUG_VERBOSE is not defined
    */
   void printDetails(void);
 
@@ -922,32 +922,40 @@ private:
    * @return Current value of status register
    */
   uint8_t get_status(void);
-
-#ifdef DEBUG
+ 
   /**
-   * Decode and print the given status to stdout
+   * Print the current feature register value to serial
+   *
+   * @warning Does nothing if DEBUG is not defined
+   */
+  void print_feature(void);
+ 
+  /**
+   * Decode and print the given status to serial
+   *
+   * @warning Does nothing if MY_DEBUG_VERBOSE is not defined
    *
    * @param status Status value to print
-   *
-   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
    */
-  void print_status(uint8_t status);
+  void print_status(uint8_t status) const;
 
   /**
-   * Decode and print the given 'observe_tx' value to stdout
+   * Decode and print the given 'observe_tx' value to serial
+   *
+   * @warning Does nothing if MY_DEBUG_VERBOSE is not defined
    *
    * @param value The observe_tx value to print
-   *
-   * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
    */
-  void print_observe_tx(uint8_t value);
+  void print_observe_tx(uint8_t value) const;
 
   /**
-   * Print the value of an 8-bit register to stdout
+   * Print the value of an 8-bit register to serial
    *
    * Optionally it can print some quantity of successive
    * registers on the same line.  This is useful for printing a group
    * of related registers on one line.
+   *
+   * @warning Does nothing if MY_DEBUG_VERBOSE is not defined
    *
    * @param reg Which register. Use constants from nRF24L01.h
    * @param qty How many successive registers to print
@@ -955,27 +963,19 @@ private:
   void print_byte_register(uint8_t reg, uint8_t qty = 1);
 
   /**
-   * Print the value of a 40-bit address register to stdout
+   * Print the value of a 40-bit address register to serial
    *
    * Optionally it can print some quantity of successive
    * registers on the same line.  This is useful for printing a group
    * of related registers on one line.
+   *
+   * @warning Does nothing if MY_DEBUG_VERBOSE is not defined
    *
    * @param reg Which register. Use constants from nRF24L01.h
    * @param qty How many successive registers to print
    */
   void print_address_register(uint8_t reg, uint8_t qty = 1);
 
-  /**
-   * Print a value in hex to serial output.
-   *
-   * For values < 16 a leading 0 will be printed.
-   *
-   * @param v  Value to print in hex.
-   */
-  void print_hex( uint8_t v, const bool prefix0x = false );
-  
-#endif
   /**
    * Turn on or off the special features of the chip
    *

--- a/libraries/MySensors/utility/RF24_config.h
+++ b/libraries/MySensors/utility/RF24_config.h
@@ -23,8 +23,6 @@
 
   /*** USER DEFINES:  ***/  
   //#define FAILURE_HANDLING
-  //#define SERIAL_DEBUG  
-  #define MINIMAL
   //#define SPI_UART  // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
   //#define SOFTSPI   // Requires library from https://github.com/greiman/DigitalIO
   /**********************/
@@ -74,16 +72,7 @@
   #define _SPI SPI
 #endif
 
-  
-  #ifdef SERIAL_DEBUG
-	#define IF_SERIAL_DEBUG(x) ({x;})
-  #else
-	#define IF_SERIAL_DEBUG(x)
-	#if defined(RF24_TINY)
-	#define printf_P(...)
-    #endif
-  #endif
-
+ 
 // Avoid spurious warnings
 // Arduino DUE is arm and uses traditional PROGMEM constructs
 #if 1
@@ -99,7 +88,6 @@
 // Arduino DUE is arm and does not include avr/pgmspace
 #if defined(__AVR__)
 	#include <avr/pgmspace.h>
-	#define PRIPSTR "%S"
 #else
 #if defined(ESP8266)
 #include <pgmspace.h>
@@ -119,9 +107,6 @@
 	#define PROGMEM
 	#define pgm_read_word(p) (*(p))
 #endif
-
-	#define PRIPSTR "%s"
-
 #endif
 
 


### PR DESCRIPTION
Switched from printf_P to Serial.print to prevent all kinds of nasty
PROGMEM troubles.
Distinguish between 32- and 16-bit architectures when reading ptrs from
flash.
Ditched #defines MINIMAL & SERIAL_DEBUG.
Debugging code is now only included when DEBUG is defined.
If your target (e.g. ATTiny) cannot handle the extra code, then don't
enable DEBUG.
#defining DEBUG will now also output a register-dump on calling begin()
of NRF24 driver to aid in (connection) problems.