### PR TITLE
Fix printDetails() & debugging for ESP8266

### DIFF
--- a/libraries/MySensors/drivers/RF24/RF24.h
+++ b/libraries/MySensors/drivers/RF24/RF24.h
@@ -923,7 +923,7 @@ private:
    */
   uint8_t get_status(void);
 
-  #if !defined (MINIMAL)
+#ifdef DEBUG
   /**
    * Decode and print the given status to stdout
    *
@@ -943,30 +943,38 @@ private:
   void print_observe_tx(uint8_t value);
 
   /**
-   * Print the name and value of an 8-bit register to stdout
+   * Print the value of an 8-bit register to stdout
    *
    * Optionally it can print some quantity of successive
    * registers on the same line.  This is useful for printing a group
    * of related registers on one line.
    *
-   * @param name Name of the register
    * @param reg Which register. Use constants from nRF24L01.h
    * @param qty How many successive registers to print
    */
-  void print_byte_register(const char* name, uint8_t reg, uint8_t qty = 1);
+  void print_byte_register(uint8_t reg, uint8_t qty = 1);
 
   /**
-   * Print the name and value of a 40-bit address register to stdout
+   * Print the value of a 40-bit address register to stdout
    *
    * Optionally it can print some quantity of successive
    * registers on the same line.  This is useful for printing a group
    * of related registers on one line.
    *
-   * @param name Name of the register
    * @param reg Which register. Use constants from nRF24L01.h
    * @param qty How many successive registers to print
    */
-  void print_address_register(const char* name, uint8_t reg, uint8_t qty = 1);
+  void print_address_register(uint8_t reg, uint8_t qty = 1);
+
+  /**
+   * Print a value in hex to serial output.
+   *
+   * For values < 16 a leading 0 will be printed.
+   *
+   * @param v  Value to print in hex.
+   */
+  void print_hex( uint8_t v, const bool prefix0x = false );
+  
 #endif
   /**
    * Turn on or off the special features of the chip

--- a/libraries/MySensors/drivers/RF24/RF24_config.h
+++ b/libraries/MySensors/drivers/RF24/RF24_config.h
@@ -23,8 +23,6 @@
 
   /*** USER DEFINES:  ***/  
   //#define FAILURE_HANDLING
-  //#define SERIAL_DEBUG
-  #define MINIMAL
   //#define SPI_UART  // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
   //#define MY_SOFTSPI   // Requires library from https://github.com/greiman/DigitalIO
   /**********************/
@@ -76,16 +74,7 @@
   #define _SPI SPI
 #endif
 
-  
-  #ifdef SERIAL_DEBUG
-	#define IF_SERIAL_DEBUG(x) ({x;})
-  #else
-	#define IF_SERIAL_DEBUG(x)
-	#if defined(RF24_TINY)
-	#define printf_P(...)
-    #endif
-  #endif
-
+ 
 // Avoid spurious warnings
 // Arduino DUE is arm and uses traditional PROGMEM constructs
 #if 1
@@ -101,7 +90,6 @@
 // Arduino DUE is arm and does not include avr/pgmspace
 #if defined(__AVR__)
 	#include <avr/pgmspace.h>
-	#define PRIPSTR "%S"
 #else
 #if defined(ESP8266)
 #include <pgmspace.h>
@@ -121,9 +109,6 @@
 	#define PROGMEM
 	#define pgm_read_word(p) (*(p))
 #endif
-
-	#define PRIPSTR "%s"
-
 #endif
 
 


### PR DESCRIPTION
Switched from printf_P to Serial.print to prevent all kinds of nasty
PROGMEM troubles.
Distinguish between 32- and 16-bit architectures when reading ptrs from
flash.
Ditched #defines MINIMAL & SERIAL_DEBUG.
Debugging code is now only included when DEBUG is defined.
If your target (e.g. ATTiny) cannot handle the extra code, then don't
enable DEBUG.
#defining DEBUG will now also output a register-dump on calling begin()
of NRF24 driver to aid in (connection) problems.