### PR TITLE
Changed library version to comply with Semantic Versioning

### DIFF
--- a/libraries/MySensors/core/Version.h
+++ b/libraries/MySensors/core/Version.h
@@ -6,6 +6,6 @@
 #ifndef Version_h
 #define Version_h
 
-#define LIBRARY_VERSION "1.6"
+#define LIBRARY_VERSION "1.6.0-beta"
 
 #endif


### PR DESCRIPTION
New version: 1.6.0-beta for development of 1.6.0.
See http://semver.org