### PR TITLE
prevent duplicate definition of period_t, which is used by LowPower.h

### DIFF
--- a/libraries/MySensors/MyHwATMega328.h
+++ b/libraries/MySensors/MyHwATMega328.h
@@ -78,7 +78,9 @@ do { 																\
 #define hw_writeConfigBlock(__pos, __buf, __length) (eeprom_write_block((void*)(__pos), (void*)__buf, (__length)))
 
 
-
+// if LowPower.h from LowPowerLab is used, the names will conflict.
+// Please #import LowPower.h BEFORE MySensors.h!
+#ifndef LowPower_h
 enum period_t
 {
 	SLEEP_15Ms,
@@ -93,6 +95,7 @@ enum period_t
 	SLEEP_8S,
 	SLEEP_FOREVER
 };
+#endif
 
 class MyHwATMega328 : public MyHw
 { 


### PR DESCRIPTION
small workaround. We should think about not using this exact name, even if `gw.sleep(enum period_t`want's to reproduce (but not replace) LowPower's sleep functionality.