### PR TITLE
Add V_CUSTOM for controller/inter-node specific commands.

### DIFF
--- a/libraries/MySensors/core/MyMessage.h
+++ b/libraries/MySensors/core/MyMessage.h
@@ -142,6 +142,7 @@ typedef enum {
 	V_HVAC_SETPOINT_HEAT, // S_HEATER, S_HVAC. HVAC/Heater setpoint (Integer between 0-100)
 	V_HVAC_FLOW_MODE, // S_HVAC. Flow mode for HVAC ("Auto", "ContinuousOn", "PeriodicOn")
 	V_TEXT, // S_INFO. Text message to display on LCD or controller device
+	V_CUSTOM 		// Custom messages used for controller/inter node specific commands, preferably using S_CUSTOM device type.
 } mysensor_data;
 
 


### PR DESCRIPTION
Requested by rob@domoticz for handling request of internal device
values. This variable/command should not be used for any of the official
sketches among the examples when communicating with controller.