### PR TITLE
Added support for private configuration data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 stino.settings
 *~
 *bak
+MyPrivateConfig.h

--- a/libraries/MySensors/core/MyPrivateConfig.h.sample
+++ b/libraries/MySensors/core/MyPrivateConfig.h.sample
@@ -1,0 +1,71 @@
+/**
+ * The MySensors Arduino library handles the wireless radio link and protocol
+ * between your home built sensors/actuators and HA controller of choice.
+ * The sensors forms a self healing radio network with optional repeaters. Each
+ * repeater and gateway builds a routing tables in EEPROM which keeps track of the
+ * network topology allowing messages to be routed to nodes.
+ *
+ * Created by Henrik Ekblad <henrik.ekblad@mysensors.org>
+ * Copyright (C) 2013-2015 Sensnology AB
+ * Full contributor list: https://github.com/mysensors/Arduino/graphs/contributors
+ *
+ * Documentation: http://www.mysensors.org
+ * Support Forum: http://forum.mysensors.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ */
+/*
+ * This file contains settings that for various reasons are unsuitable to store in git
+ * Rename it by removing the .sample extension and place it in the sketch folder and include
+ * it in the sketch:
+ * #include "MyPrivateConfig.h"
+ * Make sure to include it before
+ * #include <MySensor.h>
+ * Then adapt the contents to your personal preference.
+ */
+
+#ifndef MyPrivateConfig_h
+#define MyPrivateConfig_h
+
+/**********************************
+*  Node identification Settings
+***********************************/
+//#define MY_NODE_ID 1
+
+/**********************************
+*  Message Signing Settings
+***********************************/
+// Pin used for random generation in soft signing (do not connect anything to this when enabled)
+#define MY_SIGNING_SOFT_RANDOMSEED_PIN 7 // A7 -
+
+// Set the soft_serial value to an arbitrary value for proper security
+#define MY_SIGNING_SOFT_SERIAL 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09
+
+// Key to use for HMAC calculation in MySigningAtsha204Soft (32 bytes)
+#define MY_SIGNING_SOFT_HMAC_KEY 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+
+// Enable node whitelisting
+//#define MY_SIGNING_NODE_WHITELISTING {{.nodeId = GATEWAY_ADDRESS,.serial = {0x09,0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01}}}
+
+/**********************************
+*  NRF24L01 Driver Defaults
+***********************************/
+// Enables RF24 encryption (all nodes and gateway must have this enabled)
+//#define MY_RF24_ENABLE_ENCRYPTION
+
+// Default encryption key
+#define MY_RF24_ENCRYPTKEY 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x10,0x11,0x12,0x13,0x14,0x15,0x16
+
+/**********************************
+*  RFM69 Driver Defaults
+***********************************/
+// Default network id. Use the same for all nodes that will talk to each other
+#define MY_RFM69_NETWORKID     100
+
+// Enable this for encryption of packets
+//#define MY_RFM69_ENABLE_ENCRYPTION
+#define MY_RFM69_ENCRYPTKEY    "sampleEncryptKey" //exactly the same 16 characters/bytes on all nodes!
+
+#endif


### PR DESCRIPTION
libraries/MySensors/core/MyPrivateConfig.h.sample contain an example for
how private configuration data can be organized.
Rename that file to MyPrivateConfig.h and place it in the same folder
as the sketch you want to build and include it in order to add private
settings that you for various reasons do not want to store in git:
Make sure to place this include before

All MyPrivateConfig.h files are ignored by git.