### PR TITLE
esp8266gateway crashing when receiving I_CONFIG message from new node…

### DIFF
--- a/libraries/MySensors/core/MySensorCore.cpp
+++ b/libraries/MySensors/core/MySensorCore.cpp
@@ -241,7 +241,11 @@ void _processInternalMessages() {
 	} else if (type == I_CONFIG) {
 		// Pick up configuration from controller (currently only metric/imperial)
 		// and store it in eeprom if changed
-		isMetric = _msg.getString()[0] == 'M' ;
+	 	if (_msg.getString() == NULL) {
+                        isMetric = true;
+                } else {
+                        isMetric = _msg.getString()[0] == 'M' ;
+                }
 		_cc.isMetric = isMetric;
 		hwWriteConfig(EEPROM_CONTROLLER_CONFIG_ADDRESS, isMetric);
 	} else if (type == I_PRESENTATION) {


### PR DESCRIPTION
… due to attempt to dereference the NULL return of MyMessage::getString()

this fix checks for NULL return from getString and defaults isMetric to true, otherwise attempts the usual match. Works for me so far. Not tested on AVR.

( I AGREE TO THE CLA )