### PR TITLE
Fix DallasTemperatureSensor Example

### DIFF
--- a/libraries/MySensors/examples/DallasTemperatureSensor/DallasTemperatureSensor.ino
+++ b/libraries/MySensors/examples/DallasTemperatureSensor/DallasTemperatureSensor.ino
@@ -53,13 +53,14 @@ MyMessage msg(0,V_TEMP);
 
 void setup()  
 { 
+}
+
+void presentation() {
   // Startup up the OneWire library
   sensors.begin();
   // requestTemperatures() will not block current thread
   sensors.setWaitForConversion(false);
-}
-
-void presentation() {
+  
   // Send the sketch version information to the gateway and Controller
   sendSketchInfo("Temperature Sensor", "1.1");
 


### PR DESCRIPTION
presentation() is called before setup(), so unless we call sensors.begin() in presentation(), sensors.getDeviceCount() will always return zero.