### PR TITLE
Fix compile error using ESP board 2.0.0

### DIFF
--- a/libraries/MySensors/core/MyMainESP8266.cpp
+++ b/libraries/MySensors/core/MyMainESP8266.cpp
@@ -42,12 +42,12 @@ static os_event_t g_loop_queue[LOOP_QUEUE_SIZE];
 
 static uint32_t g_micros_at_task_start;
 
-
+/*
 extern "C" void abort() {
     do {
         *((int*)0) = 0;
     } while(true);
-}
+}*/
 
 extern "C" void esp_yield() {
     if (cont_can_yield(&g_cont)) {


### PR DESCRIPTION
You need to update to the latest ESP board files 2.0.0 by using
Tools->Board->Boards-Manager. Select ESP8266 and press Update.