### PR TITLE
WDT fixes

### DIFF
--- a/libraries/MySensors/core/MyHw.h
+++ b/libraries/MySensors/core/MyHw.h
@@ -43,8 +43,8 @@ uint8_t hwReadConfig(int adr);
 */
 
 void hwSleep(unsigned long ms);
-bool hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms);
-uint8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms);
+int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms);
+int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms);
 #ifdef MY_DEBUG
 	void hwDebugPrint(const char *fmt, ... );
 #endif

--- a/libraries/MySensors/core/MyHwESP8266.cpp
+++ b/libraries/MySensors/core/MyHwESP8266.cpp
@@ -96,12 +96,12 @@ void hwSleep(unsigned long ms) {
   // TODO: Not supported!
 }
 
-bool hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
+int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
   // TODO: Not supported!
 	return false;
 }
 
-uint8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
+int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
   // TODO: Not supported!
 	return 0;
 }


### PR DESCRIPTION
- removed redundant code
- bugfix for sleeping (forever) with WDT on resulting in wake-up
- fix: restore WDT settings after sleeping, thus, if WDT was on before sleeping, it will be re-activated after sleeping
- return code: -1=no interrupt triggered (WDT timeout), 0=INT0, 1=INT1
