### PR TITLE
Fixing smartsleep, define return value for sleep()

### DIFF
--- a/libraries/MySensors/core/MyHw.h
+++ b/libraries/MySensors/core/MyHw.h
@@ -42,7 +42,7 @@ void hwWriteConfig(int adr, uint8_t value);
 uint8_t hwReadConfig(int adr);
 */
 
-void hwSleep(unsigned long ms);
+int8_t hwSleep(unsigned long ms);
 int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms);
 int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms);
 #ifdef MY_DEBUG

--- a/libraries/MySensors/core/MyHwATMega328.cpp
+++ b/libraries/MySensors/core/MyHwATMega328.cpp
@@ -94,8 +94,9 @@ void hwInternalSleep(unsigned long ms) {
 	if (!pinIntTrigger && ms >= 16)      { hwPowerDown(SLEEP_15Ms); ms -= 15; }
 }
 
-void hwSleep(unsigned long ms) {
+int8_t hwSleep(unsigned long ms) {
 	hwInternalSleep(ms);
+	return -1;
 }
 
 int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
@@ -120,7 +121,7 @@ int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mo
 	detachInterrupt(interrupt1);
 	if (interrupt2!=0xFF) detachInterrupt(interrupt2);
 	
-	// default: no interrupt triggered	
+	// default: no interrupt triggered, timer wake up	
 	int8_t retVal = -1;
 
 	if (pinIntTrigger == 1) {

--- a/libraries/MySensors/core/MyHwESP8266.cpp
+++ b/libraries/MySensors/core/MyHwESP8266.cpp
@@ -92,18 +92,19 @@ void hwWriteConfig(int adr, uint8_t value)
 
 
 
-void hwSleep(unsigned long ms) {
-  // TODO: Not supported!
+int8_t hwSleep(unsigned long ms) {
+	// TODO: Not supported!
+	return -2;
 }
 
 int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
-  // TODO: Not supported!
-	return false;
+	// TODO: Not supported!
+	return -2;
 }
 
 int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
   // TODO: Not supported!
-	return 0;
+	return -2;
 }
 
 #ifdef MY_DEBUG

--- a/libraries/MySensors/core/MyHwSAMD.cpp
+++ b/libraries/MySensors/core/MyHwSAMD.cpp
@@ -113,25 +113,25 @@ void hwReboot() {
 
 int8_t hwSleep(unsigned long ms) {
   // TODO: Not supported!
-  ms = ms + 1;
+  (void)ms;
   return -2;
 }
 
 int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
   // TODO: Not supported!
-  interrupt = interrupt;
-  mode = mode;
-  ms = ms;
+  (void)interrupt;
+  (void)mode;
+  (void)ms;
   return -2;
 }
 
 int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
   // TODO: Not supported!
-  interrupt1 = interrupt1;
-  mode1 = mode1;
-  interrupt2 = interrupt2;
-  mode2 = mode2;
-  ms = ms;
+  (void)interrupt1;
+  (void)mode1;
+  (void)interrupt2;
+  (void)mode2;
+  (void)ms;
   return -2;
 }
 

--- a/libraries/MySensors/core/MyHwSAMD.cpp
+++ b/libraries/MySensors/core/MyHwSAMD.cpp
@@ -111,9 +111,10 @@ void hwReboot() {
  // TODO: Not supported!
 }
 
-void hwSleep(unsigned long ms) {
+int8_t hwSleep(unsigned long ms) {
   // TODO: Not supported!
   ms = ms + 1;
+  return -2;
 }
 
 int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
@@ -121,7 +122,7 @@ int8_t hwSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
   interrupt = interrupt;
   mode = mode;
   ms = ms;
-	return false;
+  return -2;
 }
 
 int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
@@ -131,7 +132,7 @@ int8_t hwSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mo
   interrupt2 = interrupt2;
   mode2 = mode2;
   ms = ms;
-  return 0;
+  return -2;
 }
 
 #ifdef MY_DEBUG

--- a/libraries/MySensors/core/MySensorCore.cpp
+++ b/libraries/MySensors/core/MySensorCore.cpp
@@ -319,13 +319,20 @@ int8_t sleep(unsigned long ms) {
 	#if defined(MY_OTA_FIRMWARE_FEATURE)
 	if (_fwUpdateOngoing) {
 		// Do not sleep node while fw update is ongoing
-		return -2;
+		wait(ms);
+		return -1;
 	}
 	#endif
-	#if defined(MY_RADIO_FEATURE)
-		transportPowerDown();
+	// if repeater, do not sleep
+	#if defined(MY_REPEATER_FEATURE)
+		wait(ms);
+		return -1;
+	#else
+		#if defined(MY_RADIO_FEATURE)
+			transportPowerDown();
+		#endif
+		return hwSleep(ms);
 	#endif
-	return hwSleep(ms);
 }
 
 int8_t smartSleep(unsigned long ms) {
@@ -340,14 +347,19 @@ int8_t smartSleep(unsigned long ms) {
 int8_t sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
 	#if defined(MY_OTA_FIRMWARE_FEATURE)
 	if (_fwUpdateOngoing) {
-		// Do not sleep node while fw update is ongoing
+		// not supported
 		return -2;
 	}
 	#endif
-	#if defined(MY_RADIO_FEATURE)
-		transportPowerDown();
+	#if defined(MY_REPEATER_FEATURE)
+		// not supported
+		return -2;
+	#else
+		#if defined(MY_RADIO_FEATURE)
+			transportPowerDown();
+		#endif
+		return hwSleep(interrupt, mode, ms);
 	#endif
-	return hwSleep(interrupt, mode, ms);
 }
 
 int8_t smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
@@ -362,14 +374,19 @@ int8_t smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
 int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
 	#if defined(MY_OTA_FIRMWARE_FEATURE)
 	if (_fwUpdateOngoing) {
-		// Do not sleep node while fw update is ongoing
+		// not supported
 		return -2;
 	}
 	#endif
-	#if defined(MY_RADIO_FEATURE)
-		transportPowerDown();
+	#if defined(MY_REPEATER_FEATURE)
+		// not supported
+		return -2;
+	#else
+		#if defined(MY_RADIO_FEATURE)
+			transportPowerDown();
+		#endif
+		return hwSleep(interrupt1, mode1, interrupt2, mode2, ms);
 	#endif
-	return hwSleep(interrupt1, mode1, interrupt2, mode2, ms);
 }
 
 int8_t smartSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {

--- a/libraries/MySensors/core/MySensorCore.cpp
+++ b/libraries/MySensors/core/MySensorCore.cpp
@@ -353,9 +353,9 @@ int8_t sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
 	#endif
 	#if defined(MY_REPEATER_FEATURE)
 		// not supported
-		interrupt = interrupt;
-		mode = mode;
-		ms = ms;
+		(void)interrupt;
+		(void)mode;
+		(void)ms;
 		return -2;
 	#else
 		#if defined(MY_RADIO_FEATURE)
@@ -383,11 +383,11 @@ int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode
 	#endif
 	#if defined(MY_REPEATER_FEATURE)
 		// not supported
-		interrupt1 = interrupt1;
-		mode1 = mode1;
-		interrupt2 = interrupt2;
-		mode2 = mode2;
-		ms = ms;
+		(void)interrupt1;
+		(void)mode1;
+		(void)interrupt2;
+		(void)mode2;
+		(void)ms;
 		return -2;
 	#else
 		#if defined(MY_RADIO_FEATURE)

--- a/libraries/MySensors/core/MySensorCore.cpp
+++ b/libraries/MySensors/core/MySensorCore.cpp
@@ -353,6 +353,9 @@ int8_t sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
 	#endif
 	#if defined(MY_REPEATER_FEATURE)
 		// not supported
+		interrupt = interrupt;
+		mode = mode;
+		ms = ms;
 		return -2;
 	#else
 		#if defined(MY_RADIO_FEATURE)
@@ -380,6 +383,11 @@ int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode
 	#endif
 	#if defined(MY_REPEATER_FEATURE)
 		// not supported
+		interrupt1 = interrupt1;
+		mode1 = mode1;
+		interrupt2 = interrupt2;
+		mode2 = mode2;
+		ms = ms;
 		return -2;
 	#else
 		#if defined(MY_RADIO_FEATURE)

--- a/libraries/MySensors/core/MySensorCore.cpp
+++ b/libraries/MySensors/core/MySensorCore.cpp
@@ -315,49 +315,47 @@ void wait(unsigned long ms) {
 	}
 }
 
-void sleep(unsigned long ms) {
-	#if defined(MY_OTA_FIRMWARE_FEATURE)
-		if (_fwUpdateOngoing) {
-			// Do not sleep node while fw update is ongoing
-			_process();
-			return;
-		} else {
-	#endif
-		#if defined(MY_RADIO_FEATURE)
-			transportPowerDown();
-		#endif
-			hwSleep(ms);
-	#if defined(MY_OTA_FIRMWARE_FEATURE)
-		}
-	#endif
-}
-
-void smartSleep(unsigned long ms) {
-	wait(MY_SMART_SLEEP_WAIT_DURATION);
-	sleep(ms);
-	sendHeartbeat();
-}
-
-bool sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
+int8_t sleep(unsigned long ms) {
 	#if defined(MY_OTA_FIRMWARE_FEATURE)
 	if (_fwUpdateOngoing) {
 		// Do not sleep node while fw update is ongoing
-		return false;
-	} else {
-	#endif
-		#if defined(MY_RADIO_FEATURE)
-			transportPowerDown();
-		#endif
-		return hwSleep(interrupt, mode, ms) ;
-	#if defined(MY_OTA_FIRMWARE_FEATURE)
+		return -2;
 	}
 	#endif
+	#if defined(MY_RADIO_FEATURE)
+		transportPowerDown();
+	#endif
+	return hwSleep(ms);
 }
 
-bool smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
-	wait(MY_SMART_SLEEP_WAIT_DURATION);
-	bool ret = sleep(interrupt, mode, ms);
+int8_t smartSleep(unsigned long ms) {
+	int8_t ret = sleep(ms);
+	// notifiy controller about wake up
 	sendHeartbeat();
+	// listen for incoming messages
+	wait(MY_SMART_SLEEP_WAIT_DURATION);
+	return ret;
+}
+
+int8_t sleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
+	#if defined(MY_OTA_FIRMWARE_FEATURE)
+	if (_fwUpdateOngoing) {
+		// Do not sleep node while fw update is ongoing
+		return -2;
+	}
+	#endif
+	#if defined(MY_RADIO_FEATURE)
+		transportPowerDown();
+	#endif
+	return hwSleep(interrupt, mode, ms);
+}
+
+int8_t smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms) {
+	int8_t ret = sleep(interrupt, mode, ms);
+	// notifiy controller about wake up
+	sendHeartbeat();
+	// listen for incoming messages
+	wait(MY_SMART_SLEEP_WAIT_DURATION);
 	return ret;
 }
 
@@ -365,22 +363,21 @@ int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode
 	#if defined(MY_OTA_FIRMWARE_FEATURE)
 	if (_fwUpdateOngoing) {
 		// Do not sleep node while fw update is ongoing
-		return -1;
-	} else {
-	#endif
-		#if defined(MY_RADIO_FEATURE)
-			transportPowerDown();
-		#endif
-		return hwSleep(interrupt1, mode1, interrupt2, mode2, ms) ;
-	#if defined(MY_OTA_FIRMWARE_FEATURE)
+		return -2;
 	}
 	#endif
+	#if defined(MY_RADIO_FEATURE)
+		transportPowerDown();
+	#endif
+	return hwSleep(interrupt1, mode1, interrupt2, mode2, ms);
 }
 
 int8_t smartSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms) {
-	wait(MY_SMART_SLEEP_WAIT_DURATION);
 	int8_t ret = sleep(interrupt1, mode1, interrupt2, mode2, ms);
+	// notifiy controller about wake up
 	sendHeartbeat();
+	// listen for incoming messages
+	wait(MY_SMART_SLEEP_WAIT_DURATION);
 	return ret;
 }
 

--- a/libraries/MySensors/core/MySensorCore.h
+++ b/libraries/MySensors/core/MySensorCore.h
@@ -178,9 +178,10 @@ void wait(unsigned long ms);
 /**
  * Sleep (PowerDownMode) the MCU and radio. Wake up on timer.
  * @param ms Number of milliseconds to sleep.
+ * @return -1 if timer woke it up, -2 if not possible (e.g. ongoing FW update)
  */
-void sleep(unsigned long ms);
-void smartSleep(unsigned long ms);
+int8_t sleep(unsigned long ms);
+int8_t smartSleep(unsigned long ms);
 
 /**
  * Sleep (PowerDownMode) the MCU and radio. Wake up on timer or pin change.
@@ -189,10 +190,10 @@ void smartSleep(unsigned long ms);
  * @param interrupt Interrupt that should trigger the wakeup
  * @param mode RISING, FALLING, CHANGE
  * @param ms Number of milliseconds to sleep or 0 to sleep forever
- * @return true if wake up was triggered by pin change and false means timer woke it up.
+ * @return Interrupt number wake up was triggered by pin change, -1 if timer woke it up, -2 if not possible (e.g. ongoing FW update)
  */
-bool sleep(uint8_t interrupt, uint8_t mode, unsigned long ms=0);
-bool smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms=0);
+int8_t sleep(uint8_t interrupt, uint8_t mode, unsigned long ms=0);
+int8_t smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms=0);
 
 /**
  * Sleep (PowerDownMode) the MCU and radio. Wake up on timer or pin change for two separate interrupts.
@@ -203,7 +204,7 @@ bool smartSleep(uint8_t interrupt, uint8_t mode, unsigned long ms=0);
  * @param interrupt2 Second interrupt that should trigger the wakeup
  * @param mode2 Mode for second interrupt (RISING, FALLING, CHANGE)
  * @param ms Number of milliseconds to sleep or 0 to sleep forever
- * @return Interrupt number wake up was triggered by pin change and negative if timer woke it up.
+ * @return Interrupt number wake up was triggered by pin change, -1 if timer woke it up, -2 if not possible (e.g. ongoing FW update)
  */
 int8_t sleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms=0);
 int8_t smartSleep(uint8_t interrupt1, uint8_t mode1, uint8_t interrupt2, uint8_t mode2, unsigned long ms=0);


### PR DESCRIPTION
- Fixing smartSleep(): 
  change order of actions: sleep()>heartbeat()>wait() / before: wait()>sleep()>sendHeartbeat() 
  This allows for receiving and processing commands after sleeping (if supported by the controller)
- Harmonize sleep return values: -2 not possible (e.g. FW update ongoing, not implemented), -1 timer wake up, >=0 interrupt# wake up. 