### PR TITLE
Fix wrong value returned in isAckPayloadAvailable()

### DIFF
--- a/libraries/MySensors/drivers/RF24/RF24.cpp
+++ b/libraries/MySensors/drivers/RF24/RF24.cpp
@@ -1168,7 +1168,7 @@ void RF24::writeAckPayload(uint8_t pipe, const void* buf, uint8_t len)
 
 bool RF24::isAckPayloadAvailable(void)
 {
-  return ! read_register(FIFO_STATUS) & _BV(RX_EMPTY);
+  return !(read_register(FIFO_STATUS) & _BV(RX_EMPTY));
 }
 
 /****************************************************************************/


### PR DESCRIPTION
Logical not (!) precedes bitwise and (&), thus wrong evaluation of the return term.