### PR TITLE
Limiting max. precision in dtostrf()

### DIFF
--- a/libraries/MySensors/core/MyMessage.cpp
+++ b/libraries/MySensors/core/MyMessage.cpp
@@ -100,7 +100,7 @@ char* MyMessage::getString(char *buffer) const {
 		} else if (payloadType == P_ULONG32) {
 			ultoa(ulValue, buffer, 10);
 		} else if (payloadType == P_FLOAT32) {
-			dtostrf(fValue,2,fPrecision,buffer);
+			dtostrf(fValue,2,min(fPrecision, 8),buffer);
 		} else if (payloadType == P_CUSTOM) {
 			return getCustomString(buffer);
 		}


### PR DESCRIPTION
Buffer overflow has been reported reported https://github.com/mysensors/Arduino/issues/312

This fix will limit the max. precision to 8
