### PR TITLE
ClearEepromConfig: Use EEPROM.update instead of EEPROM.write

### DIFF
--- a/libraries/MySensors/examples/ClearEepromConfig/ClearEepromConfig.ino
+++ b/libraries/MySensors/examples/ClearEepromConfig/ClearEepromConfig.ino
@@ -32,7 +32,7 @@ void setup()
   Serial.begin(MY_BAUD_RATE);
   Serial.println("Started clearing. Please wait...");
   for (int i=0;i<512;i++) {
-    EEPROM.write(i, 0xff);
+    EEPROM.update(i, 0xff);
   }
   Serial.println("Clearing done. You're ready to go!");
 }


### PR DESCRIPTION
EEprom has limited write cycles, so don't write unless we need to.
This also speeds up the clearing. My test results:
write: 1,700ms
update, all cells needs to be updated: 1,600ms
update, no cells need to be updated: 4ms

See https://www.arduino.cc/en/Reference/EEPROMUpdate for more
information on the udpate function.

I agree to CLA.