### PR TITLE
LED HW definitions in arduino HW files overridable

### DIFF
--- a/hardware/MySensors/samd/variants/mysensors_gw/variant.h
+++ b/hardware/MySensors/samd/variants/mysensors_gw/variant.h
@@ -191,9 +191,9 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 
 
 #define MY_SIGNING_ATSHA204_PIN 17
-#define MY_DEFAULT_ERR_LED_PIN LED_RED
-#define MY_DEFAULT_RX_LED_PIN  LED_YELLOW
-#define MY_DEFAULT_TX_LED_PIN  LED_GREEN
+#define MY_HW_ERR_LED_PIN LED_RED
+#define MY_HW_RX_LED_PIN  LED_YELLOW
+#define MY_HW_TX_LED_PIN  LED_GREEN
 
 /*----------------------------------------------------------------------------
  *        Arduino objects - C++ only

--- a/libraries/MySensors/MySensor.h
+++ b/libraries/MySensors/MySensor.h
@@ -56,6 +56,28 @@
         #include "core/MyHwSAMD.cpp"
 #endif
 
+#if !defined(MY_DEFAULT_ERR_LED_PIN) & defined(MY_HW_ERR_LED_PIN)
+	#define MY_DEFAULT_ERR_LED_PIN MY_HW_ERR_LED_PIN
+#endif
+
+#if !defined(MY_DEFAULT_TX_LED_PIN) && defined(MY_HW_TX_LED_PIN)
+	#define MY_DEFAULT_TX_LED_PIN MY_HW_TX_LED_PIN
+#endif
+
+#if !defined(MY_DEFAULT_RX_LED_PIN) && defined(MY_HW_TX_LED_PIN)
+	#define MY_DEFAULT_TX_LED_PIN MY_HW_TX_LED_PIN
+#endif
+
+// Not necessary to include blinking feature if no LED's are defined!
+#if defined(MY_LEDS_BLINKING_FEATURE) && !defined(MY_DEFAULT_RX_LED_PIN) && !defined(MU_DEFAULT_TX_LED_PIN) && !defined(MY_ERR_LED_PIN)
+	#undefine MY_LEDS_BLINKING_FEATURE
+#endif
+
+// Enable LED BLINKING FEATURE, if there are any LEDs defined.
+#if defined(MY_DEFAULT_RX_LED_PIN) || defined(MY_DEFAULT_ERR_LED) || defined(MY_DEFAULT_TX_LED_PIN)
+	#define MY_LEDS_BLINKING_FEATURE
+#endif
+
 // LEDS
 #if defined(MY_LEDS_BLINKING_FEATURE)
 	#include "core/MyLeds.cpp"

--- a/libraries/MySensors/MySensor.h
+++ b/libraries/MySensors/MySensor.h
@@ -70,7 +70,7 @@
 
 // Not necessary to include blinking feature if no LED's are defined!
 #if defined(MY_LEDS_BLINKING_FEATURE) && !defined(MY_DEFAULT_RX_LED_PIN) && !defined(MU_DEFAULT_TX_LED_PIN) && !defined(MY_ERR_LED_PIN)
-	#undefine MY_LEDS_BLINKING_FEATURE
+	#undef MY_LEDS_BLINKING_FEATURE
 #endif
 
 // Enable LED BLINKING FEATURE, if there are any LEDs defined.

--- a/libraries/MySensors/examples/GatewaySerial/GatewaySerial.ino
+++ b/libraries/MySensors/examples/GatewaySerial/GatewaySerial.ino
@@ -72,11 +72,10 @@
 // Digital pin used for inclusion mode button
 #define MY_INCLUSION_MODE_BUTTON_PIN  3 
 
-#ifndef MY_DEFAULT_ERR_LED_PIN
-#define MY_DEFAULT_ERR_LED_PIN 4  // Error led pin
-#define MY_DEFAULT_RX_LED_PIN  6  // Receive led pin
-#define MY_DEFAULT_TX_LED_PIN  5  // the PCB, on board LED
-#endif
+// Uncomment to override default HW configurations
+//#define MY_DEFAULT_ERR_LED_PIN 4  // Error led pin
+//#define MY_DEFAULT_RX_LED_PIN  6  // Receive led pin
+//#define MY_DEFAULT_TX_LED_PIN  5  // the PCB, on board LED
 
 #include <SPI.h>
 #include <MySensor.h>  

--- a/libraries/MySensors/examples/GatewayW5100/GatewayW5100.ino
+++ b/libraries/MySensors/examples/GatewayW5100/GatewayW5100.ino
@@ -100,11 +100,10 @@
 // Digital pin used for inclusion mode button
 #define MY_INCLUSION_MODE_BUTTON_PIN  3 
 
-#ifndef MY_DEFAULT_ERR_LED_PIN
-#define MY_DEFAULT_ERR_LED_PIN 7  // Error led pin
-#define MY_DEFAULT_RX_LED_PIN  8  // Receive led pin
-#define MY_DEFAULT_TX_LED_PIN  9  // the PCB, on board LED
-#endif
+// Uncomment to override default HW configurations
+//#define MY_DEFAULT_ERR_LED_PIN 7  // Error led pin
+//#define MY_DEFAULT_RX_LED_PIN  8  // Receive led pin
+//#define MY_DEFAULT_TX_LED_PIN  9  // the PCB, on board LED
 
 #include <SPI.h>
 

--- a/libraries/MySensors/examples/GatewayW5100MQTTClient/GatewayW5100MQTTClient.ino
+++ b/libraries/MySensors/examples/GatewayW5100MQTTClient/GatewayW5100MQTTClient.ino
@@ -125,9 +125,10 @@
 // Digital pin used for inclusion mode button
 #define MY_INCLUSION_MODE_BUTTON_PIN  3 
 
-#define MY_DEFAULT_ERR_LED_PIN 16  // Error led pin
-#define MY_DEFAULT_RX_LED_PIN  16  // Receive led pin
-#define MY_DEFAULT_TX_LED_PIN  16  // the PCB, on board LED
+// Uncomment to override default HW configurations
+//#define MY_DEFAULT_ERR_LED_PIN 16  // Error led pin
+//#define MY_DEFAULT_RX_LED_PIN  16  // Receive led pin
+//#define MY_DEFAULT_TX_LED_PIN  16  // the PCB, on board LED
 */
 
 #include <Ethernet.h>


### PR DESCRIPTION
Use MY_HW_xx_LED_PIN, if it is defined in board specific files, AND if MY_DEFAULT_xx_LED_PIN is not defined.

Commented out MY_DEFAULT_xx_LED_PIN defines in gateway sketches

if MY_DEFAULT_XX_LED_PIN is defined, it also enables MY_LEDS_BLINKING_FEATURE

If MY_LED_BLINKING_FEATURE is enabled, but no MY_DEFAULT_xx_LED_PIN are defined, then it will undefine MY_LED_BLINKING_FEATURE, as it doesn't make sense to include it if no LED's are defined. 