### PR TITLE
Null termination issue, Fixes #322

### DIFF
--- a/libraries/MySensors/core/MyMessage.cpp
+++ b/libraries/MySensors/core/MyMessage.cpp
@@ -203,10 +203,11 @@ MyMessage& MyMessage::set(const char* value) {
 	uint8_t length = value == NULL ? 0 : min(strlen(value), MAX_PAYLOAD);
 	miSetLength(length);
 	miSetPayloadType(P_STRING);
-	if (length)
+	if (length) {		
 		strncpy(data, value, length);
-	else
-		data[0] ='\0';
+	}
+	// null terminate string
+	data[length] = 0;
 	return *this;
 }
 


### PR DESCRIPTION
string null termination missing in MyMessage.set(char*)