### PR TITLE
Use the internal pullup to be able to hook up this sketch directly to S0 meters

### DIFF
--- a/libraries/MySensors/examples/EnergyMeterPulseSensor/EnergyMeterPulseSensor.ino
+++ b/libraries/MySensors/examples/EnergyMeterPulseSensor/EnergyMeterPulseSensor.ino
@@ -73,7 +73,7 @@ void setup()
 
   // Use the internal pullup to be able to hook up this sketch directly to an energy meter with S0 output
   // If no pullup is used, the reported usage will be too high because of the floating pin
-  digitalWrite(DIGITAL_INPUT_SENSOR,HIGH);
+  pinMode(DIGITAL_INPUT_SENSOR,INPUT_PULLUP);
   
   attachInterrupt(INTERRUPT, onPulse, RISING);
   lastSend=millis();

--- a/libraries/MySensors/examples/EnergyMeterPulseSensor/EnergyMeterPulseSensor.ino
+++ b/libraries/MySensors/examples/EnergyMeterPulseSensor/EnergyMeterPulseSensor.ino
@@ -70,6 +70,10 @@ void setup()
 {  
   // Fetch last known pulse count value from gw
   request(CHILD_ID, V_VAR1);
+
+  // Use the internal pullup to be able to hook up this sketch directly to an energy meter with S0 output
+  // If no pullup is used, the reported usage will be too high because of the floating pin
+  digitalWrite(DIGITAL_INPUT_SENSOR,HIGH);
   
   attachInterrupt(INTERRUPT, onPulse, RISING);
   lastSend=millis();


### PR DESCRIPTION
If no pullup is used, the reported usage will be too high because of the floating pin.

Since an S0-enabled meter acts like a switch, we need a resistor to keep the pin from floating. 