### PR TITLE
The gateway sent wrong signing information to node with MY_SIGNING_RE…

### DIFF
--- a/libraries/MySensors/core/MySigning.cpp
+++ b/libraries/MySensors/core/MySigning.cpp
@@ -102,7 +102,7 @@ static void prepareSigningPresentation(MyMessage &msg, uint8_t destination) {
 	build(msg, _nc.nodeId, destination, NODE_SENSOR_ID, C_INTERNAL, I_SIGNING_PRESENTATION, false).set("");
 	mSetLength(msg, 2);
 	msg.data[0] = SIGNING_PRESENTATION_VERSION_1;
-	msg.data[1] = 0;
+//	msg.data[1] = 0;
 }
 
 void signerInit(void) {


### PR DESCRIPTION
…QUEST_SIGNATURES enabled

The gateway does not care about the node's signing state, while msg.data[1] = 0; in the signature verification process.

In this case the part of the log of the gateway:
0;255;3;0;9;Mark node 3 as one that require signed messages
0;255;3;0;9;Mark node 3 as one that do not require whitelisting
0;255;3;0;9;Informing node 0 that we do not require signatures
0;255;3;0;9;Informing node 0 that we do not require whitelisting

I removed this line, and now it works properly.