### PR TITLE
Compatibility with atmega32U4 (Arduino micro)

### DIFF
--- a/libraries/MySensors/core/MyMainDefault.cpp
+++ b/libraries/MySensors/core/MyMainDefault.cpp
@@ -3,7 +3,9 @@
 int main(void) {
 	init();
 	#if defined(USBCON)
-		USBDevice.init();
+		#if defined(ARDUINO_ARCH_SAMD)
+			USBDevice.init();
+		#endif
     		USBDevice.attach();
 	#endif
 	_begin(); // Startup MySensors library


### PR DESCRIPTION
For atmega32U4-boards USBDevice.init(); must not be called. This is only necessary for SAMD-boards.
With this patch the library works fine with an arduino micro board.