### PR TITLE
Resend presentation if client connected

### DIFF
--- a/libraries/MySensors/core/MyGatewayTransportEthernet.cpp
+++ b/libraries/MySensors/core/MyGatewayTransportEthernet.cpp
@@ -288,6 +288,8 @@ bool gatewayTransportAvailable()
 						_w5100_spi_en(false);
 						gatewayTransportSend(buildGw(_msg, I_GATEWAY_READY).set("Gateway startup complete."));
 						_w5100_spi_en(true);
+						if (presentation)
+							presentation();
 					}
 				}
 				bool connected = clients[i].connected();
@@ -318,6 +320,8 @@ bool gatewayTransportAvailable()
 					debug(PSTR("Eth: connect\n"));
 					_w5100_spi_en(false);
 					gatewayTransportSend(buildGw(_msg, I_GATEWAY_READY).set("Gateway startup complete."));
+					if (presentation)
+						presentation();
 				}
 			}
 			if (client) {


### PR DESCRIPTION
This change solve the problem described  here:
http://forum.mysensors.org/topic/2112/n00b-ethernet-gw-without-nf24

The presentation must be resent when the client connects. Without this Domoticz catches only sensor data, and doesn't know about connected actuators.