### PR TITLE
Set the serial port speed to 38400 on Arduino's running on 8MHz oscillator

### DIFF
--- a/libraries/MySensors/MyConfig.h
+++ b/libraries/MySensors/MyConfig.h
@@ -30,7 +30,11 @@
 #define ENABLED_SERIAL
 
 // Serial output baud rate (for debug prints and serial gateway)
+#if F_CPU == 8000000L
+#define BAUD_RATE 38400
+#else
 #define BAUD_RATE 115200
+#endif
 
 
 /**********************************


### PR DESCRIPTION
If the serial gateway is built on SenseBender or Arduino Pro Mini 3.3V,
the serial port speed must be limited to 38400. This is the highest
reliable speed on ATmega processors running on the internal 8 MHz oscillator.