### PR TITLE
Set the serial port speed of the Serial Gateway to 38400 on Arduino's  running on 8MHz oscillator

### DIFF
--- a/libraries/MySensors/examples/GatewaySerial/GatewaySerial.ino
+++ b/libraries/MySensors/examples/GatewaySerial/GatewaySerial.ino
@@ -51,6 +51,11 @@
 // Enable serial gateway
 #define MY_GATEWAY_SERIAL
 
+// Define a lower baud rate for Arduino's running on 8 MHz (Arduino Pro Mini 3.3V & SenseBender)
+#if F_CPU == 8000000L
+#define MY_BAUD_RATE 38400
+#endif
+
 // Flash leds on rx/tx/err
 #define MY_LEDS_BLINKING_FEATURE
 // Set blinking period


### PR DESCRIPTION
On 8 MHz clock speed the actual 115200 bps rate is so much off that sending
data over serial is very unreliable.