### PR TITLE
Fix exception in esp8266 gateway. 

### DIFF
--- a/libraries/MySensors/core/MyGatewayTransportEthernet.cpp
+++ b/libraries/MySensors/core/MyGatewayTransportEthernet.cpp
@@ -134,9 +134,6 @@ bool gatewayTransportInit() {
 	#else
 		// we have to use pointers due to the constructor of EthernetServer
 		_ethernetServer.begin();
-		#if defined(MY_GATEWAY_ESP8266)
-			_ethernetServer.setNoDelay(true);
-		#endif
 	#endif /* USE_UDP */
 	_w5100_spi_en(false);
 	return true;


### PR DESCRIPTION
An incompatibility exists with the wifi SetNoDelay() code between esp8266/Arduino version 2.0.0 and 2.1.0. This patch solves the problem for MySensors ESP8266 gateway until the SDK is fixed.
See https://github.com/esp8266/Arduino/issues/1695 for details of the actual problem.
The symptom is a gateway that keeps restarting after connection to controller due to an exception.

The solution was found by @sle118 in Mar 2016