### PR TITLE
Allow User to manage ESP8266 Wifi if need

### DIFF
--- a/libraries/MySensors/core/MyGatewayTransportEthernet.cpp
+++ b/libraries/MySensors/core/MyGatewayTransportEthernet.cpp
@@ -100,18 +100,20 @@ typedef struct
 bool gatewayTransportInit() {
 	_w5100_spi_en(true);
 	#if defined(MY_GATEWAY_ESP8266)
-		(void)WiFi.begin(MY_ESP8266_SSID, MY_ESP8266_PASSWORD);
-		#ifdef MY_IP_ADDRESS
-			WiFi.config(_ethernetGatewayIP, gateway, subnet);
+		#if defined(MY_ESP8266_SSID)
+			(void)WiFi.begin(MY_ESP8266_SSID, MY_ESP8266_PASSWORD);
+			#ifdef MY_IP_ADDRESS
+				WiFi.config(_ethernetGatewayIP, gateway, subnet);
+			#endif
+			while (WiFi.status() != WL_CONNECTED)
+			{
+				delay(500);
+				MY_SERIALDEVICE.print(".");
+				yield();
+			}
+			MY_SERIALDEVICE.print(F("IP: "));
+			MY_SERIALDEVICE.println(WiFi.localIP());
 		#endif
-		while (WiFi.status() != WL_CONNECTED)
-		{
-			delay(500);
-			MY_SERIALDEVICE.print(".");
-			yield();
-		}
-		MY_SERIALDEVICE.print(F("IP: "));
-		MY_SERIALDEVICE.println(WiFi.localIP());
 
 	#else
 		#ifdef MY_IP_ADDRESS


### PR DESCRIPTION
If MY_ESP8266_SSID is not defined, the WIFI part is managed by the user.
If MY_ESP8266_SSID is defined, wifi is managed by Mysensor libraries.