### PR TITLE
Add destination parameter to signingPresentation

### DIFF
--- a/libraries/MySensors/core/MySigning.cpp
+++ b/libraries/MySensors/core/MySigning.cpp
@@ -129,8 +129,8 @@ void signerInit(void) {
 #endif
 }
 
-void signerPresentation(MyMessage &msg) {
-	prepareSigningPresentation(msg, GATEWAY_ADDRESS);
+void signerPresentation(MyMessage &msg, uint8_t destination) {
+	prepareSigningPresentation(msg, destination);
 
 #if defined(MY_SIGNING_REQUEST_SIGNATURES)
 	msg.data[1] |= SIGNING_PRESENTATION_REQUIRE_SIGNATURES;
@@ -145,8 +145,10 @@ void signerPresentation(MyMessage &msg) {
 
 #if defined(MY_SIGNING_FEATURE)
 	// If we do support signing, wait for the gateway to tell us how it prefer us to transmit our messages
-	SIGN_DEBUG(PSTR("Waiting for GW to send signing preferences...\n"));
-	wait(2000);
+	if (destination == GATEWAY_ADDRESS) {
+		SIGN_DEBUG(PSTR("Waiting for GW to send signing preferences...\n"));
+		wait(2000);
+	}
 #endif
 }
 

--- a/libraries/MySensors/core/MySigning.h
+++ b/libraries/MySensors/core/MySigning.h
@@ -157,6 +157,8 @@
  * Just set the flag @ref MY_SIGNING_REQUEST_SIGNATURES and the node will inform the gateway that it expects the gateway to sign all
  * messages sent to the node. If this is set in a gateway, it will @b NOT force all nodes to sign messages to it. It will only require
  * signatures from nodes that in turn require signatures.<br>
+ * If you want to have two nodes communicate securely directly with each other, the nodes that require signatures must send a presentation
+ * message to all nodes it expect signed messages from (only the gateway is informed automatically). See @ref signerPresentation().<br>
  * A node can have three "states" with respect to signing:
  * 1. Node does not support signing in any way (neither @ref MY_SIGNING_ATSHA204 nor @ref MY_SIGNING_SOFT is set)
  * 2. Node does support signing but don't require messages sent to it to be signed (@ref MY_SIGNING_REQUEST_SIGNATURES is not set)
@@ -506,14 +508,19 @@ void signerInit(void);
 /**
  * @brief Does signing specific presentation for a node.
  *
- * This function makes sure any signing related presentation info is shared with the gateway.
+ * This function makes sure any signing related presentation info is shared with the other part.
  * The presentation of the gateways signing preferences is done in @ref signerProcessInternal().
  * \n@b Usage: This function should be called by the presentation routine of the mysensors library.
- * There is no need to call this directly from a sketch.
+ * You only need to call this directly from a sketch to set up a node to node signed message exchange.
+ * If you do call this directly from a sketch, and you at some point change your sketch to go from
+ * requireing signing to not requireing signatures, you need to present this change to the node at least
+ * once, so it can update its requirements tables accordingly. Or it will keep believing that this node
+ * require signatures and attempt to send signed messages to it.
  *
  * @param msg Message buffer to use.
+ * @param destination Node ID of the destination.
  */
-void signerPresentation(MyMessage &msg);
+void signerPresentation(MyMessage &msg, uint8_t destination);
  
 /**
  * @brief Manages internal signing message handshaking.

--- a/libraries/MySensors/core/MyTransport.cpp
+++ b/libraries/MySensors/core/MyTransport.cpp
@@ -454,8 +454,8 @@ void transportPresentNode() {
 	// Present node and request config
 	#ifndef MY_GATEWAY_FEATURE
 		if (_nc.nodeId != AUTO) {
-			// Send signing preferences for this node
-			signerPresentation(_msg);
+			// Send signing preferences for this node to the GW
+			signerPresentation(_msg, GATEWAY_ADDRESS);
 
 			// Send presentation for this radio node
 			#ifdef MY_REPEATER_FEATURE


### PR DESCRIPTION
In order to allow a node to send signed messages to another node
the signingPresentation function can be called to make a
node2node presentation of signing preferences.
It is up to the sketch developer to make sure updated signing
preferences are communicated accordingly.