### PR TITLE
Utilize digitalPinToInterrupt in examples

### DIFF
--- a/libraries/MySensors/examples/EnergyMeterPulseSensor/EnergyMeterPulseSensor.ino
+++ b/libraries/MySensors/examples/EnergyMeterPulseSensor/EnergyMeterPulseSensor.ino
@@ -48,7 +48,6 @@
 #define PULSE_FACTOR 1000       // Nummber of blinks per KWH of your meeter
 #define SLEEP_MODE false        // Watt-value can only be reported when sleep mode is false.
 #define MAX_WATT 10000          // Max watt value to report. This filetrs outliers.
-#define INTERRUPT DIGITAL_INPUT_SENSOR-2 // Usually the interrupt = pin -2 (on uno/nano anyway)
 #define CHILD_ID 1              // Id of the sensor child
 
 unsigned long SEND_FREQUENCY = 20000; // Minimum time between send (in milliseconds). We don't wnat to spam the gateway.
@@ -74,8 +73,8 @@ void setup()
   // Use the internal pullup to be able to hook up this sketch directly to an energy meter with S0 output
   // If no pullup is used, the reported usage will be too high because of the floating pin
   pinMode(DIGITAL_INPUT_SENSOR,INPUT_PULLUP);
-  
-  attachInterrupt(INTERRUPT, onPulse, RISING);
+
+  attachInterrupt(digitalPinToInterrupt(DIGITAL_INPUT_SENSOR), onPulse, RISING);
   lastSend=millis();
 }
 

--- a/libraries/MySensors/examples/IrrigationController/IrrigationController.ino
+++ b/libraries/MySensors/examples/IrrigationController/IrrigationController.ino
@@ -184,7 +184,7 @@ void setup()
   pinMode(ledPin, OUTPUT);
   pinMode(waterButtonPin, INPUT_PULLUP);
   //pinMode(waterButtonPin, INPUT);
-  attachInterrupt(1, PushButton, RISING); //May need to change for your Arduino model
+  attachInterrupt(digitalPinToInterrupt(waterButtonPin), PushButton, RISING); //May need to change for your Arduino model
   digitalWrite (ledPin, HIGH);
   DEBUG_PRINTLN(F("Turning All Valves Off..."));
   updateRelays(ALL_VALVES_OFF);

--- a/libraries/MySensors/examples/LightningSensor/LightningSensor.ino
+++ b/libraries/MySensors/examples/LightningSensor/LightningSensor.ino
@@ -17,9 +17,9 @@
 
 // setup CS pins used for the connection with the lightning sensor
 // other connections are controlled by the SPI library)
-int8_t CS_PIN  = 8;
-int8_t SI_PIN  = 7;
-int8_t IRQ_PIN = 3;                      
+#define CS_PIN 8
+#define SI_PIN 7
+#define IRQ_PIN 3
 volatile int8_t AS3935_ISR_Trig = 0;
 
 // #defines
@@ -60,7 +60,7 @@ void setup()
                   // function also powers up the chip
                   
   // enable interrupt (hook IRQ pin to Arduino Uno/Mega interrupt input: 1 -> pin 3 )
-  attachInterrupt(1, AS3935_ISR, RISING);
+  attachInterrupt(digitalPinToInterrupt(IRQ_PIN), AS3935_ISR, RISING);
   // dump the registry data to the serial port for troubleshooting purposes
   lightning0.AS3935_PrintAllRegs();
   

--- a/libraries/MySensors/examples/MotionSensor/MotionSensor.ino
+++ b/libraries/MySensors/examples/MotionSensor/MotionSensor.ino
@@ -39,7 +39,6 @@
 
 unsigned long SLEEP_TIME = 120000; // Sleep time between reports (in milliseconds)
 #define DIGITAL_INPUT_SENSOR 3   // The digital input you attached your motion sensor.  (Only 2 and 3 generates interrupt!)
-#define INTERRUPT DIGITAL_INPUT_SENSOR-2 // Usually the interrupt = pin -2 (on uno/nano anyway)
 #define CHILD_ID 1   // Id of the sensor child
 
 // Initialize motion message
@@ -65,9 +64,9 @@ void loop()
         
   Serial.println(tripped);
   send(msg.set(tripped?"1":"0"));  // Send tripped value to gw 
- 
-  // Sleep until interrupt comes in on motion sensor. Send update every two minute. 
-  sleep(INTERRUPT,CHANGE, SLEEP_TIME);
+
+  // Sleep until interrupt comes in on motion sensor. Send update every two minute.
+  sleep(digitalPinToInterrupt(DIGITAL_INPUT_SENSOR), CHANGE, SLEEP_TIME);
 }
 
 

--- a/libraries/MySensors/examples/MotionSensorRS485/MotionSensorRS485.ino
+++ b/libraries/MySensors/examples/MotionSensorRS485/MotionSensorRS485.ino
@@ -58,7 +58,6 @@
 
 unsigned long SLEEP_TIME = 120000; // Sleep time between reports (in milliseconds)
 #define DIGITAL_INPUT_SENSOR 3   // The digital input you attached your motion sensor.  (Only 2 and 3 generates interrupt!)
-#define INTERRUPT DIGITAL_INPUT_SENSOR-2 // Usually the interrupt = pin -2 (on uno/nano anyway)
 #define CHILD_ID 1   // Id of the sensor child
 
 // Initialize motion message
@@ -84,9 +83,9 @@ void loop()
         
   Serial.println(tripped);
   send(msg.set(tripped?"1":"0"));  // Send tripped value to gw 
- 
-  // Sleep until interrupt comes in on motion sensor. Send update every two minute. 
-  sleep(INTERRUPT,CHANGE, SLEEP_TIME);
+
+  // Sleep until interrupt comes in on motion sensor. Send update every two minute.
+  sleep(digitalPinToInterrupt(DIGITAL_INPUT_SENSOR), CHANGE, SLEEP_TIME);
 }
 
 

--- a/libraries/MySensors/examples/RainGauge/RainGauge.ino
+++ b/libraries/MySensors/examples/RainGauge/RainGauge.ino
@@ -59,6 +59,8 @@
 #define LUX_ON // uncomment out this line to enable BH1750 sensor
 //#define USE_DAILY // displays each time segment as an accumulation of prior periods inclusive.  Comment out to display individual daily rainfall totals in the variables sent to your controller.
 
+#define TIP_SENSOR_PIN 3
+
 #define CALIBRATE_FACTOR 60 // amount of rain per rain bucket tip e.g. 5 is .05mm
 #define DHT_LUX_DELAY 300000  //Delay in milliseconds that the DHT and LUX sensors will wait before sending data
 
@@ -116,7 +118,6 @@ MyMessage msgTrippedVar2(CHILD_ID_TRIPPED_INDICATOR, V_VAR2);
 #endif
 unsigned long sensorPreviousMillis;
 int eepromIndex;
-int tipSensorPin = 3; // Pin the tipping bucket is connected to. Must be interrupt capable pin
 int ledPin = 5; // Pin the LED is connected to.  PWM capable pin required
 unsigned long dataMillis;
 unsigned long serialInterval = 600000UL;
@@ -141,8 +142,8 @@ void setup()
   SERIAL_START(115200);
   //
   // Set up the IO
-  pinMode(tipSensorPin, INPUT_PULLUP);
-  attachInterrupt (1, sensorTipped, FALLING);  // depending on location of the hall effect sensor may need CHANGE
+  pinMode(TIP_SENSOR_PIN, INPUT_PULLUP);
+  attachInterrupt (digitalPinToInterrupt(TIP_SENSOR_PIN), sensorTipped, FALLING);  // depending on location of the hall effect sensor may need CHANGE
   pinMode(ledPin, OUTPUT);
   digitalWrite(ledPin, HIGH);
   //

--- a/libraries/MySensors/examples/VibrationSensor/VibrationSensor.ino
+++ b/libraries/MySensors/examples/VibrationSensor/VibrationSensor.ino
@@ -60,8 +60,8 @@ MyMessage vibrationMsg(CHILD_ID_VIBRATION, V_LEVEL);
 void setup()  
 {
   pinMode(VIBRATION_SENSOR_DIGITAL_PIN, INPUT);
-  attachInterrupt(1, blink, FALLING);// Trigger the blink function when the falling edge is detected
-  pinMode(SensorLED, OUTPUT);  
+  attachInterrupt(digitalPinToInterrupt(VIBRATION_SENSOR_DIGITAL_PIN), blink, FALLING); // Trigger the blink function when the falling edge is detected
+  pinMode(SensorLED, OUTPUT);
 }
 
 void presentation()  {

--- a/libraries/MySensors/examples/WaterMeterPulseSensor/WaterMeterPulseSensor.ino
+++ b/libraries/MySensors/examples/WaterMeterPulseSensor/WaterMeterPulseSensor.ino
@@ -45,7 +45,6 @@
 #include <MySensor.h>  
 
 #define DIGITAL_INPUT_SENSOR 3                  // The digital input you attached your sensor.  (Only 2 and 3 generates interrupt!)
-#define SENSOR_INTERRUPT DIGITAL_INPUT_SENSOR-2        // Usually the interrupt = pin -2 (on uno/nano anyway)
 
 #define PULSE_FACTOR 1000                       // Nummber of blinks per m3 of your meter (One rotation/liter)
 
@@ -87,7 +86,7 @@ void setup()
 
   lastSend = lastPulse = millis();
 
-  attachInterrupt(SENSOR_INTERRUPT, onPulse, FALLING);
+  attachInterrupt(digitalPinToInterrupt(DIGITAL_INPUT_SENSOR), onPulse, FALLING);
 }
 
 void presentation()  {


### PR DESCRIPTION
The examples used hard-coded values or defines to convert digital
pin number to interrupt in calls to attachInterrupt and sleep.

This has confused several people, most recently in
https://forum.mysensors.org/topic/3880/gw-sleep-on-battery-powered-magnet-door-switch/

Let digitalPinToInterrupt handle this work instead.

I agree to CLA.