### PR TITLE
Signing performance fixes

### DIFF
--- a/libraries/MySensors/core/MySigningAtsha204.cpp
+++ b/libraries/MySensors/core/MySigningAtsha204.cpp
@@ -33,17 +33,18 @@
 
 unsigned long _signing_timestamp;
 bool _signing_verification_ongoing = false;
-uint8_t _signing_current_nonce[NONCE_NUMIN_SIZE_PASSTHROUGH+SHA204_SERIAL_SZ+1];
+uint8_t _signing_verifying_nonce[NONCE_NUMIN_SIZE_PASSTHROUGH+SHA204_SERIAL_SZ+1];
+uint8_t _signing_signing_nonce[NONCE_NUMIN_SIZE_PASSTHROUGH+SHA204_SERIAL_SZ+1];
 uint8_t _signing_temp_message[SHA_MSG_SIZE];
-uint8_t _singning_rx_buffer[SHA204_RSP_SIZE_MAX];
-uint8_t _singning_tx_buffer[SHA204_CMD_SIZE_MAX];
+uint8_t _signing_rx_buffer[SHA204_RSP_SIZE_MAX];
+uint8_t _signing_tx_buffer[SHA204_CMD_SIZE_MAX];
 extern uint8_t _doWhitelist[32];
 
 #ifdef MY_SIGNING_NODE_WHITELISTING
 	const whitelist_entry_t _signing_whitelist[] = MY_SIGNING_NODE_WHITELISTING;
 #endif
 
-static void signerCalculateSignature(MyMessage &msg);
+static void signerCalculateSignature(MyMessage &msg, bool signing);
 static uint8_t* signerSha256(const uint8_t* data, size_t sz);
 
 
@@ -94,7 +95,8 @@ bool signerAtsha204CheckTimer(void) {
 		if (hwMillis() < _signing_timestamp || hwMillis() > _signing_timestamp + MY_VERIFICATION_TIMEOUT_MS) {
 			DEBUG_SIGNING_PRINTBUF(F("Verification timeout"), NULL, 0);
 			// Purge nonce
-			memset(_signing_current_nonce, 0x00, NONCE_NUMIN_SIZE_PASSTHROUGH);
+			memset(_signing_signing_nonce, 0x00, NONCE_NUMIN_SIZE_PASSTHROUGH);
+			memset(_signing_verifying_nonce, 0x00, NONCE_NUMIN_SIZE_PASSTHROUGH);
 			_signing_verification_ongoing = false;
 			return false; 
 		}
@@ -109,22 +111,22 @@ bool signerAtsha204GetNonce(MyMessage &msg) {
 	// This 32-byte random value is then hashed (SHA256) to produce the resulting nonce
 	(void)atsha204_wakeup(_signing_temp_message);
 	if (atsha204_execute(SHA204_RANDOM, RANDOM_SEED_UPDATE, 0, 0, NULL,
-								RANDOM_COUNT, _singning_tx_buffer, RANDOM_RSP_SIZE, _singning_rx_buffer) != SHA204_SUCCESS) {
+								RANDOM_COUNT, _signing_tx_buffer, RANDOM_RSP_SIZE, _signing_rx_buffer) != SHA204_SUCCESS) {
 		DEBUG_SIGNING_PRINTBUF(F("Failed to generate nonce"), NULL, 0);
 		return false;
 	}
 	for (int i = 0; i < 32; i++) {
-		_signing_current_nonce[i] = _singning_rx_buffer[SHA204_BUFFER_POS_DATA+i] ^ (hwMillis()&0xFF);
+		_signing_verifying_nonce[i] = _signing_rx_buffer[SHA204_BUFFER_POS_DATA+i] ^ (hwMillis()&0xFF);
 	}
-	memcpy(_signing_current_nonce, signerSha256(_signing_current_nonce, 32), MAX_PAYLOAD);
+	memcpy(_signing_verifying_nonce, signerSha256(_signing_verifying_nonce, 32), MAX_PAYLOAD);
 
 	atsha204_idle(); // We just idle the chip now since we expect to use it soon when the signed message arrives
 
 	// We set the part of the 32-byte nonce that does not fit into a message to 0xAA
-	memset(&_signing_current_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_current_nonce)-MAX_PAYLOAD);
+	memset(&_signing_verifying_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_verifying_nonce)-MAX_PAYLOAD);
 
 	// Transfer the first part of the nonce to the message
-	msg.set(_signing_current_nonce, MAX_PAYLOAD);
+	msg.set(_signing_verifying_nonce, MAX_PAYLOAD);
 	_signing_verification_ongoing = true;
 	_signing_timestamp = hwMillis(); // Set timestamp to determine when to purge nonce
 	// Be a little fancy to handle turnover (prolong the time allowed to timeout after turnover)
@@ -137,9 +139,9 @@ bool signerAtsha204GetNonce(MyMessage &msg) {
 void signerAtsha204PutNonce(MyMessage &msg) {
 	DEBUG_SIGNING_PRINTBUF(F("Signing backend: ATSHA204"), NULL, 0);
 
-	memcpy(_signing_current_nonce, (uint8_t*)msg.getCustom(), MAX_PAYLOAD);
+	memcpy(_signing_signing_nonce, (uint8_t*)msg.getCustom(), MAX_PAYLOAD);
 	// We set the part of the 32-byte nonce that does not fit into a message to 0xAA
-	memset(&_signing_current_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_current_nonce)-MAX_PAYLOAD);
+	memset(&_signing_signing_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_signing_nonce)-MAX_PAYLOAD);
 }
 
 bool signerAtsha204SignMsg(MyMessage &msg) {
@@ -151,14 +153,14 @@ bool signerAtsha204SignMsg(MyMessage &msg) {
 
 	// Calculate signature of message
 	mSetSigned(msg, 1); // make sure signing flag is set before signature is calculated
-	signerCalculateSignature(msg);
+	signerCalculateSignature(msg, true);
 
 	if (DO_WHITELIST(msg.destination)) {
 		// Salt the signature with the senders nodeId and the unique serial of the ATSHA device
-		memcpy(_signing_current_nonce, &_singning_rx_buffer[SHA204_BUFFER_POS_DATA], 32); // We can reuse the nonce buffer now since it is no longer needed
-		_signing_current_nonce[32] = msg.sender;
-		atsha204_getSerialNumber(&_signing_current_nonce[33]);
-		(void)signerSha256(_signing_current_nonce, 32+1+SHA204_SERIAL_SZ); // we can 'void' sha256 because the hash is already put in the correct place
+		memcpy(_signing_signing_nonce, &_signing_rx_buffer[SHA204_BUFFER_POS_DATA], 32); // We can reuse the nonce buffer now since it is no longer needed
+		_signing_signing_nonce[32] = msg.sender;
+		atsha204_getSerialNumber(&_signing_signing_nonce[33]);
+		(void)signerSha256(_signing_signing_nonce, 32+1+SHA204_SERIAL_SZ); // we can 'void' sha256 because the hash is already put in the correct place
 		DEBUG_SIGNING_PRINTBUF(F("Signature salted with serial"), NULL, 0);
 	}
 
@@ -166,10 +168,10 @@ bool signerAtsha204SignMsg(MyMessage &msg) {
 	atsha204_sleep();
 
 	// Overwrite the first byte in the signature with the signing identifier
-	_singning_rx_buffer[SHA204_BUFFER_POS_DATA] = SIGNING_IDENTIFIER;
+	_signing_rx_buffer[SHA204_BUFFER_POS_DATA] = SIGNING_IDENTIFIER;
 
 	// Transfer as much signature data as the remaining space in the message permits
-	memcpy(&msg.data[mGetLength(msg)], &_singning_rx_buffer[SHA204_BUFFER_POS_DATA], MAX_PAYLOAD-mGetLength(msg));
+	memcpy(&msg.data[mGetLength(msg)], &_signing_rx_buffer[SHA204_BUFFER_POS_DATA], MAX_PAYLOAD-mGetLength(msg));
 	DEBUG_SIGNING_PRINTBUF(F("Signature in message: "), (uint8_t*)&msg.data[mGetLength(msg)], MAX_PAYLOAD-mGetLength(msg));
 
 	return true;
@@ -193,7 +195,7 @@ bool signerAtsha204VerifyMsg(MyMessage &msg) {
 		}
 
 		DEBUG_SIGNING_PRINTBUF(F("Signature in message: "), (uint8_t*)&msg.data[mGetLength(msg)], MAX_PAYLOAD-mGetLength(msg));
-		signerCalculateSignature(msg); // Get signature of message
+		signerCalculateSignature(msg, false); // Get signature of message
 
 #ifdef MY_SIGNING_NODE_WHITELISTING
 		// Look up the senders nodeId in our whitelist and salt the signature with that data
@@ -201,10 +203,10 @@ bool signerAtsha204VerifyMsg(MyMessage &msg) {
 		for (j=0; j < NUM_OF(_signing_whitelist); j++) {
 			if (_signing_whitelist[j].nodeId == msg.sender) {
 				DEBUG_SIGNING_PRINTBUF(F("Sender found in whitelist"), NULL, 0);
-				memcpy(_signing_current_nonce, &_singning_rx_buffer[SHA204_BUFFER_POS_DATA], 32); // We can reuse the nonce buffer now since it is no longer needed
-				_signing_current_nonce[32] = msg.sender;
-				memcpy(&_signing_current_nonce[33], _signing_whitelist[j].serial, SHA204_SERIAL_SZ);
-				(void)signerSha256(_signing_current_nonce, 32+1+SHA204_SERIAL_SZ); // we can 'void' sha256 because the hash is already put in the correct place
+				memcpy(_signing_verifying_nonce, &_signing_rx_buffer[SHA204_BUFFER_POS_DATA], 32); // We can reuse the nonce buffer now since it is no longer needed
+				_signing_verifying_nonce[32] = msg.sender;
+				memcpy(&_signing_verifying_nonce[33], _signing_whitelist[j].serial, SHA204_SERIAL_SZ);
+				(void)signerSha256(_signing_verifying_nonce, 32+1+SHA204_SERIAL_SZ); // we can 'void' sha256 because the hash is already put in the correct place
 				break;
 			}
 		}
@@ -220,11 +222,11 @@ bool signerAtsha204VerifyMsg(MyMessage &msg) {
 		atsha204_sleep();
 
 		// Overwrite the first byte in the signature with the signing identifier
-		_singning_rx_buffer[SHA204_BUFFER_POS_DATA] = SIGNING_IDENTIFIER;
+		_signing_rx_buffer[SHA204_BUFFER_POS_DATA] = SIGNING_IDENTIFIER;
 
 		// Compare the caluclated signature with the provided signature
-		if (signerMemcmp(&msg.data[mGetLength(msg)], &_singning_rx_buffer[SHA204_BUFFER_POS_DATA], MAX_PAYLOAD-mGetLength(msg))) {
-			DEBUG_SIGNING_PRINTBUF(F("Signature bad: "), &_singning_rx_buffer[SHA204_BUFFER_POS_DATA], MAX_PAYLOAD-mGetLength(msg));
+		if (signerMemcmp(&msg.data[mGetLength(msg)], &_signing_rx_buffer[SHA204_BUFFER_POS_DATA], MAX_PAYLOAD-mGetLength(msg))) {
+			DEBUG_SIGNING_PRINTBUF(F("Signature bad: "), &_signing_rx_buffer[SHA204_BUFFER_POS_DATA], MAX_PAYLOAD-mGetLength(msg));
 #ifdef MY_SIGNING_NODE_WHITELISTING
 			DEBUG_SIGNING_PRINTBUF(F("Is the sender whitelisted and serial correct?"), NULL, 0);
 #endif
@@ -236,42 +238,43 @@ bool signerAtsha204VerifyMsg(MyMessage &msg) {
 	}
 }
 
-// Helper to calculate signature of msg (returned in _singning_rx_buffer[SHA204_BUFFER_POS_DATA])
-static void signerCalculateSignature(MyMessage &msg) {
+// Helper to calculate signature of msg (returned in _signing_rx_buffer[SHA204_BUFFER_POS_DATA])
+static void signerCalculateSignature(MyMessage &msg, bool signing) {
 	(void)atsha204_wakeup(_signing_temp_message);
 	memset(_signing_temp_message, 0, 32);
 	memcpy(_signing_temp_message, (uint8_t*)&msg.data[1-HEADER_SIZE], MAX_MESSAGE_LENGTH-1-(MAX_PAYLOAD-mGetLength(msg)));
 
 	// Program the data to sign into the ATSHA204
 	DEBUG_SIGNING_PRINTBUF(F("Message to process: "), (uint8_t*)&msg.data[1-HEADER_SIZE], MAX_MESSAGE_LENGTH-1-(MAX_PAYLOAD-mGetLength(msg)));
-	DEBUG_SIGNING_PRINTBUF(F("Current nonce: "), _signing_current_nonce, 32);
+	DEBUG_SIGNING_PRINTBUF(F("Current nonce: "), signing ? _signing_signing_nonce : _signing_verifying_nonce, 32);
 	(void)atsha204_execute(SHA204_WRITE, SHA204_ZONE_DATA | SHA204_ZONE_COUNT_FLAG, 8 << 3, 32, _signing_temp_message,
-									WRITE_COUNT_LONG, _singning_tx_buffer, WRITE_RSP_SIZE, _singning_rx_buffer);
+									WRITE_COUNT_LONG, _signing_tx_buffer, WRITE_RSP_SIZE, _signing_rx_buffer);
 
 	// Program the nonce to use for the signature (has to be done just before GENDIG due to chip limitations)
-	(void)atsha204_execute(SHA204_NONCE, NONCE_MODE_PASSTHROUGH, 0, NONCE_NUMIN_SIZE_PASSTHROUGH, _signing_current_nonce,
-									NONCE_COUNT_LONG, _singning_tx_buffer, NONCE_RSP_SIZE_SHORT, _singning_rx_buffer);
+	(void)atsha204_execute(SHA204_NONCE, NONCE_MODE_PASSTHROUGH, 0, NONCE_NUMIN_SIZE_PASSTHROUGH,
+									signing ? _signing_signing_nonce : _signing_verifying_nonce,
+									NONCE_COUNT_LONG, _signing_tx_buffer, NONCE_RSP_SIZE_SHORT, _signing_rx_buffer);
 
 	// Purge nonce when used
-	memset(_signing_current_nonce, 0x00, NONCE_NUMIN_SIZE_PASSTHROUGH);
+	memset(signing ? _signing_signing_nonce : _signing_verifying_nonce, 0x00, NONCE_NUMIN_SIZE_PASSTHROUGH);
 
 	// Generate digest of data and nonce
 	(void)atsha204_execute(SHA204_GENDIG, GENDIG_ZONE_DATA, 8, 0, NULL,
-									GENDIG_COUNT_DATA, _singning_tx_buffer, GENDIG_RSP_SIZE, _singning_rx_buffer);
+									GENDIG_COUNT_DATA, _signing_tx_buffer, GENDIG_RSP_SIZE, _signing_rx_buffer);
 
 	// Calculate HMAC of message+nonce digest and secret key
 	(void)atsha204_execute(SHA204_HMAC, HMAC_MODE_SOURCE_FLAG_MATCH, 0, 0, NULL,
-									HMAC_COUNT, _singning_tx_buffer, HMAC_RSP_SIZE, _singning_rx_buffer);
+									HMAC_COUNT, _signing_tx_buffer, HMAC_RSP_SIZE, _signing_rx_buffer);
 
-	DEBUG_SIGNING_PRINTBUF(F("HMAC: "), &_singning_rx_buffer[SHA204_BUFFER_POS_DATA], 32);
+	DEBUG_SIGNING_PRINTBUF(F("HMAC: "), &_signing_rx_buffer[SHA204_BUFFER_POS_DATA], 32);
 }
 
 // Helper to calculate a generic SHA256 digest of provided buffer (only supports one block)
-// The pointer to the hash is returned, but the hash is also stored in _singning_rx_buffer[SHA204_BUFFER_POS_DATA])
+// The pointer to the hash is returned, but the hash is also stored in _signing_rx_buffer[SHA204_BUFFER_POS_DATA])
 static uint8_t* signerSha256(const uint8_t* data, size_t sz) {
 	// Initiate SHA256 calculator
 	(void)atsha204_execute(SHA204_SHA, SHA_INIT, 0, 0, NULL,
-									SHA_COUNT_SHORT, _singning_tx_buffer, SHA_RSP_SIZE_SHORT, _singning_rx_buffer);
+									SHA_COUNT_SHORT, _signing_tx_buffer, SHA_RSP_SIZE_SHORT, _signing_rx_buffer);
 
 	// Calculate a hash
 	memset(_signing_temp_message, 0x00, SHA_MSG_SIZE);
@@ -281,8 +284,8 @@ static uint8_t* signerSha256(const uint8_t* data, size_t sz) {
 	_signing_temp_message[SHA_MSG_SIZE-2] = (sz >> 5);
 	_signing_temp_message[SHA_MSG_SIZE-1] = (sz << 3);
 	(void)atsha204_execute(SHA204_SHA, SHA_CALC, 0, SHA_MSG_SIZE, _signing_temp_message,
-									SHA_COUNT_LONG, _singning_tx_buffer, SHA_RSP_SIZE_LONG, _singning_rx_buffer);
+									SHA_COUNT_LONG, _signing_tx_buffer, SHA_RSP_SIZE_LONG, _signing_rx_buffer);
 
-	DEBUG_SIGNING_PRINTBUF(F("SHA256: "), &_singning_rx_buffer[SHA204_BUFFER_POS_DATA], 32);
-	return &_singning_rx_buffer[SHA204_BUFFER_POS_DATA];
+	DEBUG_SIGNING_PRINTBUF(F("SHA256: "), &_signing_rx_buffer[SHA204_BUFFER_POS_DATA], 32);
+	return &_signing_rx_buffer[SHA204_BUFFER_POS_DATA];
 }

--- a/libraries/MySensors/core/MySigningAtsha204Soft.cpp
+++ b/libraries/MySensors/core/MySigningAtsha204Soft.cpp
@@ -38,7 +38,8 @@
 Sha256Class _signing_sha256;
 unsigned long _signing_timestamp;
 bool _signing_verification_ongoing = false;
-uint8_t _signing_current_nonce[NONCE_NUMIN_SIZE_PASSTHROUGH];
+uint8_t _signing_verifying_nonce[32];
+uint8_t _signing_signing_nonce[32];
 uint8_t _signing_temp_message[32];
 static uint8_t _signing_hmac_key[32];
 uint8_t _signing_hmac[32];
@@ -49,7 +50,7 @@ static uint8_t _signing_node_serial_info[9];
 	const whitelist_entry_t _signing_whitelist[] = MY_SIGNING_NODE_WHITELISTING;
 #endif
 
-static void signerCalculateSignature(MyMessage &msg);
+static void signerCalculateSignature(MyMessage &msg, bool signing);
 
 #ifdef MY_DEBUG_VERBOSE_SIGNING
 static char i2h(uint8_t i)
@@ -102,7 +103,8 @@ bool signerAtsha204SoftCheckTimer(void) {
 		if (hwMillis() < _signing_timestamp || hwMillis() > _signing_timestamp + MY_VERIFICATION_TIMEOUT_MS) {
 			DEBUG_SIGNING_PRINTBUF(F("Verification timeout"), NULL, 0);
 			// Purge nonce
-			memset(_signing_current_nonce, 0xAA, 32);
+			memset(_signing_signing_nonce, 0xAA, 32);
+			memset(_signing_verifying_nonce, 0xAA, 32);
 			_signing_verification_ongoing = false;
 			return false; 
 		}
@@ -119,14 +121,14 @@ bool signerAtsha204SoftGetNonce(MyMessage &msg) {
 	for (int i = 0; i < 32; i++) {
 		_signing_sha256.write(random(256) ^ (hwMillis()&0xFF));
 	}
-	memcpy(_signing_current_nonce, _signing_sha256.result(), MAX_PAYLOAD);
-	DEBUG_SIGNING_PRINTBUF(F("SHA256: "), _signing_current_nonce, 32);
+	memcpy(_signing_verifying_nonce, _signing_sha256.result(), MAX_PAYLOAD);
+	DEBUG_SIGNING_PRINTBUF(F("SHA256: "), _signing_verifying_nonce, 32);
 
 	// We set the part of the 32-byte nonce that does not fit into a message to 0xAA
-	memset(&_signing_current_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_current_nonce)-MAX_PAYLOAD);
+	memset(&_signing_verifying_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_verifying_nonce)-MAX_PAYLOAD);
 
 	// Transfer the first part of the nonce to the message
-	msg.set(_signing_current_nonce, MAX_PAYLOAD);
+	msg.set(_signing_verifying_nonce, MAX_PAYLOAD);
 	_signing_verification_ongoing = true;
 	_signing_timestamp = hwMillis(); // Set timestamp to determine when to purge nonce
 	// Be a little fancy to handle turnover (prolong the time allowed to timeout after turnover)
@@ -139,9 +141,9 @@ bool signerAtsha204SoftGetNonce(MyMessage &msg) {
 void signerAtsha204SoftPutNonce(MyMessage &msg) {
 	DEBUG_SIGNING_PRINTBUF(F("Signing backend: ATSHA204Soft"), NULL, 0);
 
-	memcpy(_signing_current_nonce, (uint8_t*)msg.getCustom(), MAX_PAYLOAD);
+	memcpy(_signing_signing_nonce, (uint8_t*)msg.getCustom(), MAX_PAYLOAD);
 	// We set the part of the 32-byte nonce that does not fit into a message to 0xAA
-	memset(&_signing_current_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_current_nonce)-MAX_PAYLOAD);
+	memset(&_signing_signing_nonce[MAX_PAYLOAD], 0xAA, sizeof(_signing_signing_nonce)-MAX_PAYLOAD);
 }
 
 bool signerAtsha204SoftSignMsg(MyMessage &msg) {
@@ -153,7 +155,7 @@ bool signerAtsha204SoftSignMsg(MyMessage &msg) {
 
 	// Calculate signature of message
 	mSetSigned(msg, 1); // make sure signing flag is set before signature is calculated
-	signerCalculateSignature(msg);
+	signerCalculateSignature(msg, true);
 
 	if (DO_WHITELIST(msg.destination)) {
 		// Salt the signature with the senders nodeId and the (hopefully) unique serial The Creator has provided
@@ -195,7 +197,7 @@ bool signerAtsha204SoftVerifyMsg(MyMessage &msg) {
 
 		// Get signature of message
 		DEBUG_SIGNING_PRINTBUF(F("Signature in message: "), (uint8_t*)&msg.data[mGetLength(msg)], MAX_PAYLOAD-mGetLength(msg));
-		signerCalculateSignature(msg);
+		signerCalculateSignature(msg, false);
 
 #ifdef MY_SIGNING_NODE_WHITELISTING
 		// Look up the senders nodeId in our whitelist and salt the signature with that data
@@ -236,11 +238,11 @@ bool signerAtsha204SoftVerifyMsg(MyMessage &msg) {
 }
 
 // Helper to calculate signature of msg (returned in hmac)
-static void signerCalculateSignature(MyMessage &msg) {
+static void signerCalculateSignature(MyMessage &msg, bool signing) {
 	memset(_signing_temp_message, 0, 32);
 	memcpy(_signing_temp_message, (uint8_t*)&msg.data[1-HEADER_SIZE], MAX_MESSAGE_LENGTH-1-(MAX_PAYLOAD-mGetLength(msg)));
 	DEBUG_SIGNING_PRINTBUF(F("Message to process: "), (uint8_t*)&msg.data[1-HEADER_SIZE], MAX_MESSAGE_LENGTH-1-(MAX_PAYLOAD-mGetLength(msg)));
-	DEBUG_SIGNING_PRINTBUF(F("Current nonce: "), _signing_current_nonce, 32);
+	DEBUG_SIGNING_PRINTBUF(F("Current nonce: "), signing ? _signing_signing_nonce : _signing_verifying_nonce, 32);
 
 	// ATSHA204 calculates the HMAC with a PSK and a SHA256 digest of the following data:
 	// 32 bytes zeroes
@@ -275,9 +277,9 @@ static void signerCalculateSignature(MyMessage &msg) {
 	_signing_sha256.write(0x01); // SN[0]
 	_signing_sha256.write(0x23); // SN[1]
 	for (int i=0; i<25; i++) _signing_sha256.write(0x00);
-	for (int i=0; i<32; i++) _signing_sha256.write(_signing_current_nonce[i]);
+	for (int i=0; i<32; i++) _signing_sha256.write(signing ? _signing_signing_nonce[i] : _signing_verifying_nonce[i]);
 	// Purge nonce when used
-	memset(_signing_current_nonce, 0xAA, 32);
+	memset(signing ? _signing_signing_nonce : _signing_verifying_nonce, 0xAA, 32);
 	memcpy(_signing_temp_message, _signing_sha256.result(), 32);
 
 	// Feed "message" to HMAC calculator

--- a/libraries/MySensors/drivers/ATSHA204/ATSHA204.cpp
+++ b/libraries/MySensors/drivers/ATSHA204/ATSHA204.cpp
@@ -1,58 +1,27 @@
 #include "Arduino.h"
 #include "ATSHA204.h"
 
-// atsha204Class Constructor
-// Feed this function the Arduino-ized pin number you want to assign to the ATSHA204's SDA pin
-// This will find the DDRX, PORTX, and PINX registrs it'll need to point to to control that pin
-// As well as the bit value for each of those registers
-ATSHA204Class::ATSHA204Class(uint8_t pin)
-{	
-#if defined(ARDUINO_ARCH_AVR)
-	device_pin = digitalPinToBitMask(pin);	// Find the bit value of the pin
-	uint8_t port = digitalPinToPort(pin);	// temoporarily used to get the next three registers
-	
-	// Point to data direction register port of pin
-	device_port_DDR = portModeRegister(port);
-	// Point to output register of pin
-	device_port_OUT = portOutputRegister(port);
-	// Point to input register of pin
-	device_port_IN = portInputRegister(port);
-#else
-	device_pin = pin;
+/* Local data and function prototypes */
+
+static uint8_t device_pin;
+#ifdef ARDUINO_ARCH_AVR
+static volatile uint8_t *device_port_DDR, *device_port_OUT, *device_port_IN;
 #endif
-}
-
-void ATSHA204Class::getSerialNumber(uint8_t * response)
-{
-  uint8_t readCommand[READ_COUNT];
-  uint8_t readResponse[READ_4_RSP_SIZE];
-
-  /* read from bytes 0->3 of config zone */
-  uint8_t returnCode = sha204m_read(readCommand, readResponse, SHA204_ZONE_CONFIG, ADDRESS_SN03);
-  if (!returnCode)
-  {
-    for (int i=0; i<4; i++) // store bytes 0-3 into respones array
-    response[i] = readResponse[SHA204_BUFFER_POS_DATA+i];
-
-    /* read from bytes 8->11 of config zone */
-    returnCode = sha204m_read(readCommand, readResponse, SHA204_ZONE_CONFIG, ADDRESS_SN47);
-
-    for (int i=4; i<8; i++) // store bytes 4-7 of SN into response array
-      response[i] = readResponse[SHA204_BUFFER_POS_DATA+(i-4)];
-
-    if (!returnCode)
-    { /* Finally if last two reads were successful, read byte 8 of the SN */
-      returnCode = sha204m_read(readCommand, readResponse, SHA204_ZONE_CONFIG, ADDRESS_SN8);
-      response[8] = readResponse[SHA204_BUFFER_POS_DATA]; // Byte 8 of SN should always be 0xEE
-    }
-  }
-
-  return;
-}
+static void sha204c_calculate_crc(uint8_t length, uint8_t *data, uint8_t *crc);
+static uint8_t sha204c_check_crc(uint8_t *response);
+static void swi_set_signal_pin(uint8_t is_high);
+static uint8_t swi_receive_bytes(uint8_t count, uint8_t *buffer);
+static uint8_t swi_send_bytes(uint8_t count, uint8_t *buffer);
+static uint8_t swi_send_byte(uint8_t value);
+static uint8_t sha204p_receive_response(uint8_t size, uint8_t *response);
+static uint8_t sha204m_read(uint8_t *tx_buffer, uint8_t *rx_buffer, uint8_t zone, uint16_t address);
+static uint8_t sha204c_wakeup(uint8_t *response);
+static uint8_t sha204c_resync(uint8_t size, uint8_t *response);  
+static uint8_t sha204c_send_and_receive(uint8_t *tx_buffer, uint8_t rx_size, uint8_t *rx_buffer, uint8_t execution_delay, uint8_t execution_timeout);
 
 /* SWI bit bang functions */
 
-void ATSHA204Class::swi_set_signal_pin(uint8_t is_high)
+static void swi_set_signal_pin(uint8_t is_high)
 {
   SHA204_SET_OUTPUT();
 
@@ -62,7 +31,7 @@ void ATSHA204Class::swi_set_signal_pin(uint8_t is_high)
 	SHA204_POUT_LOW();
 }
 
-uint8_t ATSHA204Class::swi_send_bytes(uint8_t count, uint8_t *buffer)
+static uint8_t swi_send_bytes(uint8_t count, uint8_t *buffer)
 {
   uint8_t i, bit_mask;
 
@@ -106,12 +75,12 @@ uint8_t ATSHA204Class::swi_send_bytes(uint8_t count, uint8_t *buffer)
   return SWI_FUNCTION_RETCODE_SUCCESS;
 }
 
-uint8_t ATSHA204Class::swi_send_byte(uint8_t value)
+static uint8_t swi_send_byte(uint8_t value)
 {
   return swi_send_bytes(1, &value);
 }
 
-uint8_t ATSHA204Class::swi_receive_bytes(uint8_t count, uint8_t *buffer)
+static uint8_t swi_receive_bytes(uint8_t count, uint8_t *buffer)
 {
   uint8_t status = SWI_FUNCTION_RETCODE_SUCCESS;
   uint8_t i;
@@ -217,12 +186,7 @@ uint8_t ATSHA204Class::swi_receive_bytes(uint8_t count, uint8_t *buffer)
 
 /* Physical functions */
 
-void ATSHA204Class::sha204c_sleep()
-{
-  swi_send_byte(SHA204_SWI_FLAG_SLEEP);
-}
-
-uint8_t ATSHA204Class::sha204p_receive_response(uint8_t size, uint8_t *response)
+static uint8_t sha204p_receive_response(uint8_t size, uint8_t *response)
 {
   uint8_t count_byte;
   uint8_t i;
@@ -254,7 +218,7 @@ uint8_t ATSHA204Class::sha204p_receive_response(uint8_t size, uint8_t *response)
 
 /* Communication functions */
 
-uint8_t ATSHA204Class::sha204c_wakeup(uint8_t *response)
+static uint8_t sha204c_wakeup(uint8_t *response)
 {
   swi_set_signal_pin(0);
   delayMicroseconds(10*SHA204_WAKEUP_PULSE_WIDTH);
@@ -282,7 +246,7 @@ uint8_t ATSHA204Class::sha204c_wakeup(uint8_t *response)
   return ret_code;
 }
 
-uint8_t ATSHA204Class::sha204c_resync(uint8_t size, uint8_t *response)
+static uint8_t sha204c_resync(uint8_t size, uint8_t *response)
 {
   // Try to re-synchronize without sending a Wake token
   // (step 1 of the re-synchronization process).
@@ -294,7 +258,7 @@ uint8_t ATSHA204Class::sha204c_resync(uint8_t size, uint8_t *response)
   // We lost communication. Send a Wake pulse and try
   // to receive a response (steps 2 and 3 of the
   // re-synchronization process).
-  sha204c_sleep();
+  atsha204_sleep();
   ret_code = sha204c_wakeup(response);
 
   // Translate a return value of success into one
@@ -303,7 +267,7 @@ uint8_t ATSHA204Class::sha204c_resync(uint8_t size, uint8_t *response)
   return (ret_code == SHA204_SUCCESS ? SHA204_RESYNC_WITH_WAKEUP : ret_code);
 }
 
-uint8_t ATSHA204Class::sha204c_send_and_receive(uint8_t *tx_buffer, uint8_t rx_size, uint8_t *rx_buffer, uint8_t execution_delay, uint8_t execution_timeout)
+static uint8_t sha204c_send_and_receive(uint8_t *tx_buffer, uint8_t rx_size, uint8_t *rx_buffer, uint8_t execution_delay, uint8_t execution_timeout)
 {
   uint8_t ret_code = SHA204_FUNC_FAIL;
   uint8_t ret_code_resync;
@@ -445,7 +409,8 @@ uint8_t ATSHA204Class::sha204c_send_and_receive(uint8_t *tx_buffer, uint8_t rx_s
 
 
 /* Marshaling functions */
-uint8_t ATSHA204Class::sha204m_read(uint8_t *tx_buffer, uint8_t *rx_buffer, uint8_t zone, uint16_t address)
+
+static uint8_t sha204m_read(uint8_t *tx_buffer, uint8_t *rx_buffer, uint8_t zone, uint16_t address)
 {
   uint8_t rx_size;
 
@@ -462,7 +427,71 @@ uint8_t ATSHA204Class::sha204m_read(uint8_t *tx_buffer, uint8_t *rx_buffer, uint
   return sha204c_send_and_receive(&tx_buffer[0], rx_size, &rx_buffer[0], READ_DELAY, READ_EXEC_MAX - READ_DELAY);
 }
 
-uint8_t ATSHA204Class::sha204m_execute(uint8_t op_code, uint8_t param1, uint16_t param2,
+/* CRC Calculator and Checker */
+
+static void sha204c_calculate_crc(uint8_t length, uint8_t *data, uint8_t *crc)
+{
+  uint8_t counter;
+  uint16_t crc_register = 0;
+  uint16_t polynom = 0x8005;
+  uint8_t shift_register;
+  uint8_t data_bit, crc_bit;
+
+  for (counter = 0; counter < length; counter++)
+  {
+    for (shift_register = 0x01; shift_register > 0x00; shift_register <<= 1) 
+    {
+      data_bit = (data[counter] & shift_register) ? 1 : 0;
+      crc_bit = crc_register >> 15;
+
+      // Shift CRC to the left by 1.
+      crc_register <<= 1;
+
+      if ((data_bit ^ crc_bit) != 0)
+        crc_register ^= polynom;
+    }
+  }
+  crc[0] = (uint8_t) (crc_register & 0x00FF);
+  crc[1] = (uint8_t) (crc_register >> 8);
+}
+
+static uint8_t sha204c_check_crc(uint8_t *response)
+{
+  uint8_t crc[SHA204_CRC_SIZE];
+  uint8_t count = response[SHA204_BUFFER_POS_COUNT];
+
+  count -= SHA204_CRC_SIZE;
+  sha204c_calculate_crc(count, response, crc);
+
+  return (crc[0] == response[count] && crc[1] == response[count + 1])
+    ? SHA204_SUCCESS : SHA204_BAD_CRC;
+}
+
+/* Public functions */
+
+void atsha204_init(uint8_t pin)
+{ 
+#if defined(ARDUINO_ARCH_AVR)
+  device_pin = digitalPinToBitMask(pin);  // Find the bit value of the pin
+  uint8_t port = digitalPinToPort(pin); // temoporarily used to get the next three registers
+  
+  // Point to data direction register port of pin
+  device_port_DDR = portModeRegister(port);
+  // Point to output register of pin
+  device_port_OUT = portOutputRegister(port);
+  // Point to input register of pin
+  device_port_IN = portInputRegister(port);
+#else
+  device_pin = pin;
+#endif
+}
+
+void atsha204_sleep(void)
+{
+  swi_send_byte(SHA204_SWI_FLAG_SLEEP);
+}
+
+uint8_t atsha204_execute(uint8_t op_code, uint8_t param1, uint16_t param2,
 			uint8_t datalen1, uint8_t *data1,	uint8_t tx_size, uint8_t *tx_buffer, uint8_t rx_size, uint8_t *rx_buffer)
 {
 	uint8_t poll_delay, poll_timeout, response_size;
@@ -538,43 +567,30 @@ uint8_t ATSHA204Class::sha204m_execute(uint8_t op_code, uint8_t param1, uint16_t
 				&rx_buffer[0],	poll_delay, poll_timeout);
 }
 
-/* CRC Calculator and Checker */
-
-void ATSHA204Class::sha204c_calculate_crc(uint8_t length, uint8_t *data, uint8_t *crc)
+void atsha204_getSerialNumber(uint8_t * response)
 {
-  uint8_t counter;
-  uint16_t crc_register = 0;
-  uint16_t polynom = 0x8005;
-  uint8_t shift_register;
-  uint8_t data_bit, crc_bit;
+  uint8_t readCommand[READ_COUNT];
+  uint8_t readResponse[READ_4_RSP_SIZE];
 
-  for (counter = 0; counter < length; counter++)
+  /* read from bytes 0->3 of config zone */
+  uint8_t returnCode = sha204m_read(readCommand, readResponse, SHA204_ZONE_CONFIG, ADDRESS_SN03);
+  if (!returnCode)
   {
-    for (shift_register = 0x01; shift_register > 0x00; shift_register <<= 1) 
-    {
-      data_bit = (data[counter] & shift_register) ? 1 : 0;
-      crc_bit = crc_register >> 15;
+    for (int i=0; i<4; i++) // store bytes 0-3 into respones array
+    response[i] = readResponse[SHA204_BUFFER_POS_DATA+i];
 
-      // Shift CRC to the left by 1.
-      crc_register <<= 1;
+    /* read from bytes 8->11 of config zone */
+    returnCode = sha204m_read(readCommand, readResponse, SHA204_ZONE_CONFIG, ADDRESS_SN47);
 
-      if ((data_bit ^ crc_bit) != 0)
-        crc_register ^= polynom;
+    for (int i=4; i<8; i++) // store bytes 4-7 of SN into response array
+      response[i] = readResponse[SHA204_BUFFER_POS_DATA+(i-4)];
+
+    if (!returnCode)
+    { /* Finally if last two reads were successful, read byte 8 of the SN */
+      returnCode = sha204m_read(readCommand, readResponse, SHA204_ZONE_CONFIG, ADDRESS_SN8);
+      response[8] = readResponse[SHA204_BUFFER_POS_DATA]; // Byte 8 of SN should always be 0xEE
     }
   }
-  crc[0] = (uint8_t) (crc_register & 0x00FF);
-  crc[1] = (uint8_t) (crc_register >> 8);
+
+  return;
 }
-
-uint8_t ATSHA204Class::sha204c_check_crc(uint8_t *response)
-{
-  uint8_t crc[SHA204_CRC_SIZE];
-  uint8_t count = response[SHA204_BUFFER_POS_COUNT];
-
-  count -= SHA204_CRC_SIZE;
-  sha204c_calculate_crc(count, response, crc);
-
-  return (crc[0] == response[count] && crc[1] == response[count + 1])
-    ? SHA204_SUCCESS : SHA204_BAD_CRC;
-}
-

--- a/libraries/MySensors/drivers/ATSHA204/ATSHA204.h
+++ b/libraries/MySensors/drivers/ATSHA204/ATSHA204.h
@@ -239,31 +239,12 @@
 #define SHA204_PIN_READ() (*device_port_IN & device_pin)
 #endif
 
-class ATSHA204Class
-{
-private:
-	uint8_t device_pin;
-	#ifdef ARDUINO_ARCH_AVR
-	volatile uint8_t *device_port_DDR, *device_port_OUT, *device_port_IN;
-	#endif
-	void sha204c_calculate_crc(uint8_t length, uint8_t *data, uint8_t *crc);
-	uint8_t sha204c_check_crc(uint8_t *response);
-	void swi_set_signal_pin(uint8_t is_high);
-	uint8_t swi_receive_bytes(uint8_t count, uint8_t *buffer);
-	uint8_t swi_send_bytes(uint8_t count, uint8_t *buffer);
-	uint8_t swi_send_byte(uint8_t value);
-	uint8_t sha204p_receive_response(uint8_t size, uint8_t *response);
-	uint8_t sha204m_read(uint8_t *tx_buffer, uint8_t *rx_buffer, uint8_t zone, uint16_t address);
-	uint8_t sha204c_wakeup(uint8_t *response);
-	uint8_t sha204c_resync(uint8_t size, uint8_t *response);	
-	uint8_t sha204c_send_and_receive(uint8_t *tx_buffer, uint8_t rx_size, uint8_t *rx_buffer, uint8_t execution_delay, uint8_t execution_timeout);
-public:
-	ATSHA204Class(uint8_t pin);	// Constructor
-	void sha204c_sleep();
-	uint8_t sha204m_execute(uint8_t op_code, uint8_t param1, uint16_t param2,
-			uint8_t datalen1, uint8_t *data1, uint8_t tx_size, uint8_t *tx_buffer, uint8_t rx_size, uint8_t *rx_buffer);
-	void getSerialNumber(uint8_t *response);
-};
+void atsha204_init(uint8_t pin);
+void atsha204_sleep(void);
+uint8_t atsha204_execute(uint8_t op_code, uint8_t param1, uint16_t param2,
+												uint8_t datalen1, uint8_t *data1, uint8_t tx_size,
+												uint8_t *tx_buffer, uint8_t rx_size, uint8_t *rx_buffer);
+void atsha204_getSerialNumber(uint8_t *response);
 
 #endif
 #endif

--- a/libraries/MySensors/drivers/ATSHA204/ATSHA204.h
+++ b/libraries/MySensors/drivers/ATSHA204/ATSHA204.h
@@ -3,7 +3,7 @@
 #if !DOXYGEN
 #include "Arduino.h"
 
-/* This is a scaled down variant of the ATSHA204 library, tweaked to meet the specific needs of MySensors. */
+/* This is a scaled down variant of the ATSHA204 library, tweaked to meet the specific needs of the MySensors library. */
 
 /* Library return codes */
 #define SHA204_SUCCESS              ((uint8_t)  0x00) //!< Function succeeded.
@@ -240,7 +240,9 @@
 #endif
 
 void atsha204_init(uint8_t pin);
+void atsha204_idle(void);
 void atsha204_sleep(void);
+uint8_t atsha204_wakeup(uint8_t *response);
 uint8_t atsha204_execute(uint8_t op_code, uint8_t param1, uint16_t param2,
 												uint8_t datalen1, uint8_t *data1, uint8_t tx_size,
 												uint8_t *tx_buffer, uint8_t rx_size, uint8_t *rx_buffer);

--- a/libraries/MySensors/tests/Arduino/sketches/hard_signing_no_whitelisting_full_debug/hard_signing_no_whitelisting_full_debug.ino
+++ b/libraries/MySensors/tests/Arduino/sketches/hard_signing_no_whitelisting_full_debug/hard_signing_no_whitelisting_full_debug.ino
@@ -18,6 +18,8 @@
  *
  *******************************
  */
+#include <stdint.h>
+#include <pins_arduino.h>
 #define MY_DEBUG
 #define MY_DEBUG_VERBOSE_SIGNING
 #define MY_RADIO_NRF24
@@ -25,8 +27,12 @@
 #define MY_SIGNING_ATSHA204
 //#define MY_SIGNING_NODE_WHITELISTING {{.nodeId = GATEWAY_ADDRESS,.serial = {0x09,0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01}}}
 #define MY_SIGNING_REQUEST_SIGNATURES
+#ifndef MY_SIGNING_SOFT_RANDOMSEED_PIN
 #define MY_SIGNING_SOFT_RANDOMSEED_PIN 7
+#endif
+#ifndef MY_SIGNING_ATSHA204_PIN
 #define MY_SIGNING_ATSHA204_PIN 17
+#endif
 
 #include <SPI.h>
 #include <MySensor.h>

--- a/libraries/MySensors/tests/Arduino/sketches/hard_signing_whitelisting_full_debug/hard_signing_whitelisting_full_debug.ino
+++ b/libraries/MySensors/tests/Arduino/sketches/hard_signing_whitelisting_full_debug/hard_signing_whitelisting_full_debug.ino
@@ -18,6 +18,8 @@
  *
  *******************************
  */
+#include <stdint.h>
+#include <pins_arduino.h>
 #define MY_DEBUG
 #define MY_DEBUG_VERBOSE_SIGNING
 #define MY_RADIO_NRF24
@@ -25,8 +27,12 @@
 #define MY_SIGNING_ATSHA204
 #define MY_SIGNING_NODE_WHITELISTING {{.nodeId = GATEWAY_ADDRESS,.serial = {0x09,0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01}}}
 #define MY_SIGNING_REQUEST_SIGNATURES
+#ifndef MY_SIGNING_SOFT_RANDOMSEED_PIN
 #define MY_SIGNING_SOFT_RANDOMSEED_PIN 7
+#endif
+#ifndef MY_SIGNING_ATSHA204_PIN
 #define MY_SIGNING_ATSHA204_PIN 17
+#endif
 
 #include <SPI.h>
 #include <MySensor.h>

--- a/libraries/MySensors/tests/Arduino/sketches/hard_signing_whitelisting_full_debug_nodelock/hard_signing_whitelisting_full_debug_nodelock.ino
+++ b/libraries/MySensors/tests/Arduino/sketches/hard_signing_whitelisting_full_debug_nodelock/hard_signing_whitelisting_full_debug_nodelock.ino
@@ -18,6 +18,8 @@
  *
  *******************************
  */
+#include <stdint.h>
+#include <pins_arduino.h>
 #define MY_DEBUG
 #define MY_DEBUG_VERBOSE_SIGNING
 #define MY_RADIO_NRF24
@@ -25,8 +27,12 @@
 #define MY_SIGNING_ATSHA204
 #define MY_SIGNING_NODE_WHITELISTING {{.nodeId = GATEWAY_ADDRESS,.serial = {0x09,0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01}}}
 #define MY_SIGNING_REQUEST_SIGNATURES
+#ifndef MY_SIGNING_SOFT_RANDOMSEED_PIN
 #define MY_SIGNING_SOFT_RANDOMSEED_PIN 7
+#endif
+#ifndef MY_SIGNING_ATSHA204_PIN
 #define MY_SIGNING_ATSHA204_PIN 17
+#endif
 #define MY_NODE_LOCK_FEATURE
 
 #include <SPI.h>

--- a/libraries/MySensors/tests/Arduino/sketches/hard_signing_whitelisting_full_debug_nrf24_rsa/hard_signing_whitelisting_full_debug_nrf24_rsa.ino
+++ b/libraries/MySensors/tests/Arduino/sketches/hard_signing_whitelisting_full_debug_nrf24_rsa/hard_signing_whitelisting_full_debug_nrf24_rsa.ino
@@ -18,6 +18,8 @@
  *
  *******************************
  */
+#include <stdint.h>
+#include <pins_arduino.h>
 #define MY_DEBUG
 #define MY_DEBUG_VERBOSE_SIGNING
 #define MY_RADIO_NRF24
@@ -25,8 +27,12 @@
 #define MY_SIGNING_ATSHA204
 #define MY_SIGNING_NODE_WHITELISTING {{.nodeId = GATEWAY_ADDRESS,.serial = {0x09,0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01}}}
 #define MY_SIGNING_REQUEST_SIGNATURES
+#ifndef MY_SIGNING_SOFT_RANDOMSEED_PIN
 #define MY_SIGNING_SOFT_RANDOMSEED_PIN 7
+#endif
+#ifndef MY_SIGNING_ATSHA204_PIN
 #define MY_SIGNING_ATSHA204_PIN 17
+#endif
 #define MY_RF24_ENABLE_ENCRYPTION
 
 #include <SPI.h>

--- a/libraries/MySensors/tests/Arduino/sketches/hard_signing_whitelisting_full_debug_rfm69_rsa/hard_signing_whitelisting_full_debug_rfm69_rsa.ino
+++ b/libraries/MySensors/tests/Arduino/sketches/hard_signing_whitelisting_full_debug_rfm69_rsa/hard_signing_whitelisting_full_debug_rfm69_rsa.ino
@@ -18,6 +18,8 @@
  *
  *******************************
  */
+#include <stdint.h>
+#include <pins_arduino.h>
 #define MY_DEBUG
 #define MY_DEBUG_VERBOSE_SIGNING
 #define MY_RADIO_RFM69
@@ -25,8 +27,12 @@
 #define MY_SIGNING_ATSHA204
 #define MY_SIGNING_NODE_WHITELISTING {{.nodeId = GATEWAY_ADDRESS,.serial = {0x09,0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01}}}
 #define MY_SIGNING_REQUEST_SIGNATURES
+#ifndef MY_SIGNING_SOFT_RANDOMSEED_PIN
 #define MY_SIGNING_SOFT_RANDOMSEED_PIN 7
+#endif
+#ifndef MY_SIGNING_ATSHA204_PIN
 #define MY_SIGNING_ATSHA204_PIN 17
+#endif
 #define MY_RFM69_ENABLE_ENCRYPTION
 
 #include <SPI.h>

--- a/libraries/MySensors/tests/Arduino/sketches/soft_signing_no_whitelisting_full_debug/soft_signing_no_whitelisting_full_debug.ino
+++ b/libraries/MySensors/tests/Arduino/sketches/soft_signing_no_whitelisting_full_debug/soft_signing_no_whitelisting_full_debug.ino
@@ -18,6 +18,8 @@
  *
  *******************************
  */
+#include <stdint.h>
+#include <pins_arduino.h>
 #define MY_DEBUG
 #define MY_DEBUG_VERBOSE_SIGNING
 #define MY_RADIO_NRF24
@@ -25,8 +27,12 @@
 //#define MY_SIGNING_ATSHA204
 //#define MY_SIGNING_NODE_WHITELISTING {{.nodeId = GATEWAY_ADDRESS,.serial = {0x09,0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01}}}
 #define MY_SIGNING_REQUEST_SIGNATURES
+#ifndef MY_SIGNING_SOFT_RANDOMSEED_PIN
 #define MY_SIGNING_SOFT_RANDOMSEED_PIN 7
+#endif
+#ifndef MY_SIGNING_ATSHA204_PIN
 #define MY_SIGNING_ATSHA204_PIN 17
+#endif
 
 #include <SPI.h>
 #include <MySensor.h>

--- a/libraries/MySensors/tests/Arduino/sketches/soft_signing_whitelisting_full_debug/soft_signing_whitelisting_full_debug.ino
+++ b/libraries/MySensors/tests/Arduino/sketches/soft_signing_whitelisting_full_debug/soft_signing_whitelisting_full_debug.ino
@@ -18,6 +18,8 @@
  *
  *******************************
  */
+#include <stdint.h>
+#include <pins_arduino.h>
 #define MY_DEBUG
 #define MY_DEBUG_VERBOSE_SIGNING
 #define MY_RADIO_NRF24
@@ -25,8 +27,12 @@
 //#define MY_SIGNING_ATSHA204
 #define MY_SIGNING_NODE_WHITELISTING {{.nodeId = GATEWAY_ADDRESS,.serial = {0x09,0x08,0x07,0x06,0x05,0x04,0x03,0x02,0x01}}}
 #define MY_SIGNING_REQUEST_SIGNATURES
+#ifndef MY_SIGNING_SOFT_RANDOMSEED_PIN
 #define MY_SIGNING_SOFT_RANDOMSEED_PIN 7
+#endif
+#ifndef MY_SIGNING_ATSHA204_PIN
 #define MY_SIGNING_ATSHA204_PIN 17
+#endif
 
 #include <SPI.h>
 #include <MySensor.h>


### PR DESCRIPTION
Various performance enhancements related to signing:
* Reduce codesize by purging c++ class usage in atsha driver
* Improve nonce quality by mixing it with a millisecond counter to get some more entropy
* Improve nonce calculation time in HW backend by only using one ATSHA-RNG value
* Enable ATSHA204 seed update when extracting random values
* Put ATSHA204 in idle mode instead of sleep mode during ongoing signing operations to improve response times.