### PR TITLE
making MYSENSORS_LIBRARY_VERSION for purposes of being more unique

### DIFF
--- a/libraries/MySensors/core/MyGatewayTransport.cpp
+++ b/libraries/MySensors/core/MyGatewayTransport.cpp
@@ -40,7 +40,7 @@ inline void gatewayTransportProcess() {
 			if (mGetCommand(_msg) == C_INTERNAL) {
 				if (_msg.type == I_VERSION) {
 					// Request for version. Create the response
-					gatewayTransportSend(buildGw(_msg, I_VERSION).set(LIBRARY_VERSION));
+					gatewayTransportSend(buildGw(_msg, I_VERSION).set(MYSENSORS_LIBRARY_VERSION));
 				#ifdef MY_INCLUSION_MODE_FEATURE
 				} else if (_msg.type == I_INCLUSION_MODE) {
 					// Request to change inclusion mode

--- a/libraries/MySensors/core/MySensorsCore.cpp
+++ b/libraries/MySensors/core/MySensorsCore.cpp
@@ -73,7 +73,7 @@ void _begin() {
 	if (before) 
 		before();
 
-	debug(PSTR("Starting " MY_NODE_TYPE " (" MY_CAPABILITIES ", " LIBRARY_VERSION ")\n"));
+	debug(PSTR("Starting " MY_NODE_TYPE " (" MY_CAPABILITIES ", " MYSENSORS_LIBRARY_VERSION ")\n"));
 
 	#if defined(MY_LEDS_BLINKING_FEATURE)
 		ledsInit();
@@ -278,7 +278,7 @@ void sendHeartbeat(void) {
 }
 
 void present(uint8_t childSensorId, uint8_t sensorType, const char *description, bool enableAck) {
-	_sendRoute(build(_msgTmp, _nc.nodeId, GATEWAY_ADDRESS, childSensorId, C_PRESENTATION, sensorType, enableAck).set(childSensorId==NODE_SENSOR_ID?LIBRARY_VERSION:description));
+	_sendRoute(build(_msgTmp, _nc.nodeId, GATEWAY_ADDRESS, childSensorId, C_PRESENTATION, sensorType, enableAck).set(childSensorId==NODE_SENSOR_ID?MYSENSORS_LIBRARY_VERSION:description));
 }
 
 void sendSketchInfo(const char *name, const char *version, bool enableAck) {

--- a/libraries/MySensors/core/Version.h
+++ b/libraries/MySensors/core/Version.h
@@ -1,11 +1,11 @@
 /***
- *  This file defines the Sensor library version number 
+ *  This file defines the Sensor library version number
  *  Normally, contributors should not modify this directly
  *  as it is managed by the MySensors Bot.
  */
 #ifndef Version_h
 #define Version_h
 
-#define LIBRARY_VERSION "2.0.0-beta"
+#define MYSENSORS_LIBRARY_VERSION "2.0.0-beta"
 
 #endif


### PR DESCRIPTION
not sure if the AltSoftSerial.h file will be affected, but I think I got everything else

```
grep -ir LIBRARY_VERSION *                                                     [13:04:26]
MySensors/core/Version.h:#define MYSENSORS_LIBRARY_VERSION "2.0.0-beta"
MySensors/core/MyGatewayTransport.cpp:                                  gatewayTransportSend(buildGw(_msg, I_VERSION).set(MYSENSORS_LIBRARY_VERSION));
MySensors/core/MySensorsCore.cpp:       debug(PSTR("Starting " MY_NODE_TYPE " (" MY_CAPABILITIES ", " MYSENSORS_LIBRARY_VERSION ")\n"));
MySensors/core/MySensorsCore.cpp:       _sendRoute(build(_msgTmp, _nc.nodeId, GATEWAY_ADDRESS, childSensorId, C_PRESENTATION, sensorType, enableAck).set(childSensorId==NODE_SENSOR_ID?MYSENSORS_LIBRARY_VERSION:description));
MySensors/drivers/AltSoftSerial/keywords.txt:library_version    KEYWORD2
MySensors/drivers/AltSoftSerial/AltSoftSerial.h:        static int library_version() { return 1; } //!< library_version
```