### PR TITLE
Minimize FindParent collisions and minor tweaks

### DIFF
--- a/libraries/MySensors/core/MyTransport.cpp
+++ b/libraries/MySensors/core/MyTransport.cpp
@@ -44,7 +44,7 @@ void stInitTransition() {
 	_transportSM.failedUplinkTransmissions = 0;
 	_transportSM.pingActive = false;
 	_transportSM.transportActive = false;
-	#if defined(MY_TRANSPORT_SANITY_CHECK) || defined(MY_GATEWAY_FEATURE) || defined(MY_REPEATER_FEATURE)
+	#if defined(MY_TRANSPORT_SANITY_CHECK) || defined(MY_REPEATER_FEATURE)
 		_transport_lastSanityCheck = hwMillis();
 	#endif
 	_transport_lastUplinkCheck = 0;
@@ -558,7 +558,8 @@ void transportProcessMessage() {
 									_transport_lastUplinkCheck = hwMillis();
 								#endif
 								debug(PSTR("TSP:MSG:GWL OK\n")); // GW uplink ok
-								//delay(hwMillis() & 0x3ff);
+								// delay minimizes collisions
+								delay(hwMillis() & 0x3ff);
 								transportRouteMessage(build(_msgTmp, _nc.nodeId, sender, NODE_SENSOR_ID, C_INTERNAL, I_FIND_PARENT_RESPONSE, false).set(_nc.distance));
 							}
 						}
@@ -669,9 +670,9 @@ bool transportSendWrite(uint8_t to, MyMessage &message) {
 	setIndication(INDICATION_TX);
 	bool ok = transportSend(to, &message, min(MAX_MESSAGE_LENGTH, HEADER_SIZE + length));
 	
-	debug(PSTR("%sTSP:MSG:SEND %d-%d-%d-%d s=%d,c=%d,t=%d,pt=%d,l=%d,sg=%d,st=%s:%s\n"),
+	debug(PSTR("%sTSP:MSG:SEND %d-%d-%d-%d s=%d,c=%d,t=%d,pt=%d,l=%d,sg=%d,ft=%d,st=%s:%s\n"),
 			(ok || to == BROADCAST_ADDRESS ? "" : "!"),message.sender,message.last, to, message.destination, message.sensor, mGetCommand(message), message.type,
-			mGetPayloadType(message), mGetLength(message), mGetSigned(message), to==BROADCAST_ADDRESS ? "bc" : (ok ? "ok":"fail"), message.getString(_convBuf));
+			mGetPayloadType(message), mGetLength(message), mGetSigned(message), _transportSM.failedUplinkTransmissions, to==BROADCAST_ADDRESS ? "bc" : (ok ? "ok":"fail"), message.getString(_convBuf));
 	
 	return (ok || to==BROADCAST_ADDRESS);
 }

--- a/libraries/MySensors/core/MyTransport.h
+++ b/libraries/MySensors/core/MyTransport.h
@@ -27,7 +27,11 @@
 
 #include "MySensorsCore.h"
 
-#define TRANSMISSION_FAILURES  5			//!< search for a new parent node after this many transmission failures
+#if defined(MY_REPEATER_FEATURE)
+	#define TRANSMISSION_FAILURES  10		//!< search for a new parent node after this many transmission failures, higher threshold for repeating nodes
+#else
+	#define TRANSMISSION_FAILURES  5		//!< search for a new parent node after this many transmission failures, lower threshold for non-repeating nodes
+#endif
 #define TIMEOUT_FAILURE_STATE 10000			//!< duration failure state
 #define STATE_TIMEOUT 2000					//!< general state timeout
 #define STATE_RETRIES 3						//!< retries before switching to FAILURE
@@ -37,7 +41,7 @@
 #define MAX_HOPS ((uint8_t)254)				//!< maximal mumber of hops for ping/pong
 #define INVALID_HOPS ((uint8_t)255)			//!< invalid hops
 #define MAX_SUBSEQ_MSGS 5					//!< Maximum number of subsequentially processed messages in FIFO (to prevent transport deadlock if HW issue)
-#define CHKUPL_INTERVAL ((uint32_t)5000)	//!< Minimum time interval to re-check uplink
+#define CHKUPL_INTERVAL ((uint32_t)10000)	//!< Minimum time interval to re-check uplink
 
 #define _autoFindParent (bool)(MY_PARENT_NODE_ID == AUTO)				//!<  returns true if static parent id is undefined
 #define isValidDistance(distance) (bool)(distance!=DISTANCE_INVALID)	//!<  returns true if distance is valid


### PR DESCRIPTION
- Random delay to minimize collisions during findParent replies
- Set findParent threshold depending of node type
- Add failedUplinkTransmission counter to debug output (ft=%d)
- Remove redundant compiler directive