### PR TITLE
Fix to prevent sending a msg if signing failed

### DIFF
--- a/libraries/MySensors/core/MyTransport.cpp
+++ b/libraries/MySensors/core/MyTransport.cpp
@@ -661,6 +661,7 @@ bool transportSendWrite(uint8_t to, MyMessage &message) {
 	if (!signerSignMsg(message)) {
 		debug(PSTR("!TSP:MSG:SIGN fail\n"));
 		setIndication(INDICATION_ERR_SIGN);
+		return false;
 	}
 	
 	// msg length changes if signed


### PR DESCRIPTION
If singing fails, transportSendWrite() stops processing a msg and returns false