### PR TITLE
CI: Update Arduino IDE 1.8.10

### DIFF
--- a/.ci/arduino.groovy
+++ b/.ci/arduino.groovy
@@ -1,6 +1,6 @@
 #!groovy
 def buildArduino(config, String buildFlags, String sketch, String key) {
-	def root              = '/opt/arduino-1.8.9/'	
+	def root              = '/opt/arduino-1.8.10/'	
 	def build_path        = 'build'
 	def build_path_cmd    = ' -build-path '+build_path+' '
 	if (config.nightly_arduino_ide)
@@ -29,9 +29,9 @@ def parseWarnings(String key) {
  		defaultEncoding: '',
  		excludePattern: '''.*/EEPROM\\.h,.*/Dns\\.cpp,.*/socket\\.cpp,.*/util\\.h,.*/Servo\\.cpp,
  											 .*/Adafruit_NeoPixel\\.cpp,.*/UIPEthernet.*,.*/SoftwareSerial\\.cpp,
- 											 .*/pins_arduino\\.h,.*/Stream\\.cpp,.*/USBCore\\.cpp,.*/Wire\\.cpp,
+ 											 .*/pins_arduino\\.h,.*/Stream\\.cpp,.*/USBCore\\.cpp,.*/libraries/Wire/.*,
  											 .*/hardware/STM32F1.*,.*/hardware/esp8266.*,.*/hardware/esp32.*,
-											 .*/libraries/SD/.*''',
+											 .*/libraries/SD/.*,.*/libraries/Ethernet/.*''',
 
  		healthy: '', includePattern: '', messagesPattern: '',
  		parserConfigurations: [[parserName: 'Arduino/AVR', pattern: 'compiler_'+key+'.log']],


### PR DESCRIPTION
Update:
- Arduino IDE 1.8.10
- AVR board defs 1.8.1
- ESP32 1.0.3
- ESP8266 2.5.2
- SAMD 1.8.3
- STM32F1xx: 2019.9.19
- nRF5x: fix needed

currently on hold until NRF5x compiling issue resolved