### PR TITLE
Fix compile errors for Adafruit Feahter M0

### DIFF
--- a/hal/architecture/SAMD/MyHwSAMD.h
+++ b/hal/architecture/SAMD/MyHwSAMD.h
@@ -29,7 +29,11 @@
 #define CRYPTO_LITTLE_ENDIAN
 
 #ifndef MY_SERIALDEVICE
-#define MY_SERIALDEVICE SerialUSB
+	#ifdef SERIAL_PORT_MONITOR
+		#define MY_SERIALDEVICE SERIAL_PORT_MONITOR
+	#else
+		#define MY_SERIALDEVICE SerialUSB
+	#endif
 #endif
 
 #ifndef MY_DEBUGDEVICE


### PR DESCRIPTION
I would like to be able to use Adafruit Feahter M0 Hardware.
This should actually fix it for multiple boards.

I do not know why SERIAL_PORT_USBVIRTUAL and SERIAL_PORT_MONITOR not defined here:
https://github.com/mysensors/ArduinoHwSAMD/blob/master/variants/mysensors_gw/variant.h
I also do not understand the difference between MY_SERIALDEVICE MY_DEBUGDEVICE since My MY_DEBUGDEVICE semmst to be MY_SERIALDEVICE for all architectures:
https://github.com/mysensors/MySensors/tree/development/hal/architecture

The way I understand the "Arduino way" to do it would have been to use SERIAL_PORT_MONITOR instead of MY_DEBUGDEVICE
or alternatively use "#define MY_DEBUGDEVICE SERIAL_PORT_MONITOR"

Because I do not own a "MySensors SAMD Board" I cannot test the outcome I do not want to touch the:
https://github.com/mysensors/ArduinoHwSAMD/blob/master/variants/mysensors_gw/variant.h

Therfore i suggest the following solution:

#ifndef MY_SERIALDEVICE
 #ifdef SERIAL_PORT_MONITOR
  #define MY_SERIALDEVICE SERIAL_PORT_MONITOR
 #else
  #define MY_SERIALDEVICE SerialUSB
 #endif
#endif