### PR TITLE
Fixed typo in MY_RS485_DE_PIN definitions

### DIFF
--- a/hal/transport/RS485/MyTransportRS485.cpp
+++ b/hal/transport/RS485/MyTransportRS485.cpp
@@ -62,7 +62,7 @@
 #define deassertDE() hwDigitalWrite(MY_RS485_DE_PIN, LOW)
 #else
 #define assertDE() hwDigitalWrite(MY_RS485_DE_PIN, LOW); delayMicroseconds(5)
-#define deassertDE() hwDigitalWrite(MY_RS485_DE_PIN, HIG)
+#define deassertDE() hwDigitalWrite(MY_RS485_DE_PIN, HIGH)
 #endif
 #else
 #define assertDE()


### PR DESCRIPTION
Fixed typo in MY_RS485_DE_PIN definition