### PR TITLE
Added a warning about incorrect flags being used

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -420,6 +420,16 @@
 #define MY_RF24_CHANNEL (76)
 #endif
 
+// legacy - remove for 3.0.0
+/**
+* @def RF24_DATARATE
+* @brief Define this to specify a specific wireless data rate used by the RF24
+* @deprecated This flag is deprecated and replaced by @ref MY_RF24_DATARATE
+*/
+#ifdef RF24_DATARATE
+#error RF24_DATARATE is deprecated, use MY_RF24_DATARATE instead!
+#endif
+
 /**
  * @def MY_RF24_DATARATE
  * @brief RF24 data rate.


### PR DESCRIPTION
Made the preprocessor throw an error if an ancient define is specified, user must update their defines to avoid very difficult to diagnose issues further on. 

I personally stumbled upon it. I hope this PR avoids the headache for someone else.