### PR TITLE
Update PubSubClient 2.8

### DIFF
--- a/drivers/PubSubClient/CHANGES.txt
+++ b/drivers/PubSubClient/CHANGES.txt
@@ -1,3 +1,12 @@
+2.8
+   * Add setBufferSize() to override MQTT_MAX_PACKET_SIZE
+   * Add setKeepAlive() to override MQTT_KEEPALIVE
+   * Add setSocketTimeout() to overide MQTT_SOCKET_TIMEOUT
+   * Added check to prevent subscribe/unsubscribe to empty topics
+   * Declare wifi mode prior to connect in ESP example
+   * Use `strnlen` to avoid overruns
+   * Support pre-connected Client objects
+
 2.7
    * Fix remaining-length handling to prevent buffer overrun
    * Add large-payload API - beginPublish/write/publish/endPublish

--- a/drivers/PubSubClient/LICENSE.txt
+++ b/drivers/PubSubClient/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2015 Nicholas O'Leary
+Copyright (c) 2008-2020 Nicholas O'Leary
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/drivers/PubSubClient/PubSubClient.cpp
+++ b/drivers/PubSubClient/PubSubClient.cpp
@@ -1,4 +1,5 @@
 /*
+
   PubSubClient.cpp - A simple client for MQTT.
   Nick O'Leary
   http://knolleary.net
@@ -7,41 +8,51 @@
 #include "PubSubClient.h"
 #include "Arduino.h"
 
-// Suppress uninitialized member variable in all constructors because some memory can be saved with
-// on-demand initialization of these members
-// cppcheck-suppress uninitMemberVar
 PubSubClient::PubSubClient()
 {
 	this->_state = MQTT_DISCONNECTED;
 	this->_client = NULL;
 	this->stream = NULL;
 	setCallback(NULL);
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
+
 PubSubClient::PubSubClient(Client& client)
 {
 	this->_state = MQTT_DISCONNECTED;
 	setClient(client);
 	this->stream = NULL;
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
+
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client)
 {
 	this->_state = MQTT_DISCONNECTED;
 	setServer(addr, port);
 	setClient(client);
 	this->stream = NULL;
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, Client& client, Stream& stream)
 {
 	this->_state = MQTT_DISCONNECTED;
 	setServer(addr,port);
 	setClient(client);
 	setStream(stream);
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
-// cppcheck-suppress passedByValue
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client)
 {
 	this->_state = MQTT_DISCONNECTED;
@@ -49,9 +60,11 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATUR
 	setCallback(callback);
 	setClient(client);
 	this->stream = NULL;
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
-// cppcheck-suppress passedByValue
 PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client,
                            Stream& stream)
 {
@@ -60,25 +73,34 @@ PubSubClient::PubSubClient(IPAddress addr, uint16_t port, MQTT_CALLBACK_SIGNATUR
 	setCallback(callback);
 	setClient(client);
 	setStream(stream);
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
+
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client)
 {
 	this->_state = MQTT_DISCONNECTED;
 	setServer(ip, port);
 	setClient(client);
 	this->stream = NULL;
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, Client& client, Stream& stream)
 {
 	this->_state = MQTT_DISCONNECTED;
 	setServer(ip,port);
 	setClient(client);
 	setStream(stream);
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
-// cppcheck-suppress passedByValue
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client)
 {
 	this->_state = MQTT_DISCONNECTED;
@@ -86,9 +108,11 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, 
 	setCallback(callback);
 	setClient(client);
 	this->stream = NULL;
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
-// cppcheck-suppress passedByValue
 PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, Client& client,
                            Stream& stream)
 {
@@ -97,25 +121,34 @@ PubSubClient::PubSubClient(uint8_t *ip, uint16_t port, MQTT_CALLBACK_SIGNATURE, 
 	setCallback(callback);
 	setClient(client);
 	setStream(stream);
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
+
 PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client)
 {
 	this->_state = MQTT_DISCONNECTED;
 	setServer(domain,port);
 	setClient(client);
 	this->stream = NULL;
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
 PubSubClient::PubSubClient(const char* domain, uint16_t port, Client& client, Stream& stream)
 {
 	this->_state = MQTT_DISCONNECTED;
 	setServer(domain,port);
 	setClient(client);
 	setStream(stream);
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
-// cppcheck-suppress passedByValue
 PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE,
                            Client& client)
 {
@@ -124,9 +157,11 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
 	setCallback(callback);
 	setClient(client);
 	this->stream = NULL;
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
 }
-// cppcheck-suppress uninitMemberVar
-// cppcheck-suppress passedByValue
 PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGNATURE,
                            Client& client, Stream& stream)
 {
@@ -135,6 +170,15 @@ PubSubClient::PubSubClient(const char* domain, uint16_t port, MQTT_CALLBACK_SIGN
 	setCallback(callback);
 	setClient(client);
 	setStream(stream);
+	this->bufferSize = 0;
+	setBufferSize(MQTT_MAX_PACKET_SIZE);
+	setKeepAlive(MQTT_KEEPALIVE);
+	setSocketTimeout(MQTT_SOCKET_TIMEOUT);
+}
+
+PubSubClient::~PubSubClient()
+{
+	free(this->buffer);
 }
 
 bool PubSubClient::connect(const char *id)
@@ -166,11 +210,17 @@ bool PubSubClient::connect(const char *id, const char *user, const char *pass,
 	if (!connected()) {
 		int result = 0;
 
-		if (domain != NULL) {
-			result = _client->connect(this->domain, this->port);
+
+		if(_client->connected()) {
+			result = 1;
 		} else {
-			result = _client->connect(this->ip, this->port);
+			if (domain != NULL) {
+				result = _client->connect(this->domain, this->port);
+			} else {
+				result = _client->connect(this->ip, this->port);
+			}
 		}
+
 		if (result == 1) {
 			nextMsgId = 1;
 			// Leave room in the buffer for header and variable length field
@@ -185,7 +235,7 @@ bool PubSubClient::connect(const char *id, const char *user, const char *pass,
 #define MQTT_HEADER_VERSION_LENGTH 7
 #endif
 			for (j = 0; j<MQTT_HEADER_VERSION_LENGTH; j++) {
-				buffer[length++] = d[j];
+				this->buffer[length++] = d[j];
 			}
 
 			uint8_t v;
@@ -205,44 +255,43 @@ bool PubSubClient::connect(const char *id, const char *user, const char *pass,
 					v = v|(0x80>>1);
 				}
 			}
+			this->buffer[length++] = v;
 
-			buffer[length++] = v;
-
-			buffer[length++] = ((MQTT_KEEPALIVE) >> 8);
-			buffer[length++] = ((MQTT_KEEPALIVE) & 0xFF);
+			this->buffer[length++] = ((this->keepAlive) >> 8);
+			this->buffer[length++] = ((this->keepAlive) & 0xFF);
 
 			CHECK_STRING_LENGTH(length,id)
-			length = writeString(id,buffer,length);
+			length = writeString(id,this->buffer,length);
 			if (willTopic) {
 				CHECK_STRING_LENGTH(length,willTopic)
-				length = writeString(willTopic,buffer,length);
+				length = writeString(willTopic,this->buffer,length);
 				CHECK_STRING_LENGTH(length,willMessage)
-				length = writeString(willMessage,buffer,length);
+				length = writeString(willMessage,this->buffer,length);
 			}
 
 			if(user != NULL) {
 				CHECK_STRING_LENGTH(length,user)
-				length = writeString(user,buffer,length);
+				length = writeString(user,this->buffer,length);
 				if(pass != NULL) {
 					CHECK_STRING_LENGTH(length,pass)
-					length = writeString(pass,buffer,length);
+					length = writeString(pass,this->buffer,length);
 				}
 			}
 
-			write(MQTTCONNECT,buffer,length-MQTT_MAX_HEADER_SIZE);
+			write(MQTTCONNECT,this->buffer,length-MQTT_MAX_HEADER_SIZE);
 
 			lastInActivity = lastOutActivity = millis();
 
 			while (!_client->available()) {
 				unsigned long t = millis();
-				if (t-lastInActivity >= ((int32_t) MQTT_SOCKET_TIMEOUT*1000UL)) {
+				if (t-lastInActivity >= ((int32_t) this->socketTimeout*1000UL)) {
 					_state = MQTT_CONNECTION_TIMEOUT;
 					_client->stop();
 					return false;
 				}
 			}
 			uint8_t llen;
-			uint16_t len = readPacket(&llen);
+			uint32_t len = readPacket(&llen);
 
 			if (len == 4) {
 				if (buffer[3] == 0) {
@@ -270,7 +319,7 @@ bool PubSubClient::readByte(uint8_t * result)
 	while(!_client->available()) {
 		yield();
 		uint32_t currentMillis = millis();
-		if(currentMillis - previousMillis >= ((int32_t) MQTT_SOCKET_TIMEOUT * 1000)) {
+		if(currentMillis - previousMillis >= ((int32_t) this->socketTimeout * 1000)) {
 			return false;
 		}
 	}
@@ -290,18 +339,18 @@ bool PubSubClient::readByte(uint8_t * result, uint16_t * index)
 	return false;
 }
 
-uint16_t PubSubClient::readPacket(uint8_t* lengthLength)
+uint32_t PubSubClient::readPacket(uint8_t* lengthLength)
 {
 	uint16_t len = 0;
-	if(!readByte(buffer, &len)) {
+	if(!readByte(this->buffer, &len)) {
 		return 0;
 	}
-	bool isPublish = (buffer[0]&0xF0) == MQTTPUBLISH;
+	bool isPublish = (this->buffer[0]&0xF0) == MQTTPUBLISH;
 	uint32_t multiplier = 1;
-	uint16_t length = 0;
+	uint32_t length = 0;
 	uint8_t digit = 0;
 	uint16_t skip = 0;
-	uint8_t start = 0;
+	uint32_t start = 0;
 
 	do {
 		if (len == 5) {
@@ -313,47 +362,49 @@ uint16_t PubSubClient::readPacket(uint8_t* lengthLength)
 		if(!readByte(&digit)) {
 			return 0;
 		}
-		buffer[len++] = digit;
+		this->buffer[len++] = digit;
 		length += (digit & 127) * multiplier;
-		multiplier *= 128;
+		multiplier <<=7; //multiplier *= 128
 	} while ((digit & 128) != 0);
 	*lengthLength = len-1;
 
 	if (isPublish) {
 		// Read in topic length to calculate bytes to skip over for Stream writing
-		if(!readByte(buffer, &len)) {
+		if(!readByte(this->buffer, &len)) {
 			return 0;
 		}
-		if(!readByte(buffer, &len)) {
+		if(!readByte(this->buffer, &len)) {
 			return 0;
 		}
-		skip = (buffer[*lengthLength+1]<<8)+buffer[*lengthLength+2];
+		skip = (this->buffer[*lengthLength+1]<<8)+this->buffer[*lengthLength+2];
 		start = 2;
-		if (buffer[0]&MQTTQOS1) {
+		if (this->buffer[0]&MQTTQOS1) {
 			// skip message id
 			skip += 2;
 		}
 	}
+	uint32_t idx = len;
 
-	for (uint16_t i = start; i<length; i++) {
+	for (uint32_t i = start; i<length; i++) {
 		if(!readByte(&digit)) {
 			return 0;
 		}
 		if (this->stream) {
-			if (isPublish && len-*lengthLength-2>skip) {
+			if (isPublish && idx-*lengthLength-2>skip) {
 				this->stream->write(digit);
 			}
 		}
-		if (len < MQTT_MAX_PACKET_SIZE) {
-			buffer[len] = digit;
+
+		if (len < this->bufferSize) {
+			this->buffer[len] = digit;
+			len++;
 		}
-		len++;
+		idx++;
 	}
 
-	if (!this->stream && len > MQTT_MAX_PACKET_SIZE) {
+	if (!this->stream && idx > this->bufferSize) {
 		len = 0; // This will cause the packet to be ignored.
 	}
-
 	return len;
 }
 
@@ -361,15 +412,16 @@ bool PubSubClient::loop()
 {
 	if (connected()) {
 		unsigned long t = millis();
-		if ((t - lastInActivity > MQTT_KEEPALIVE*1000UL) || (t - lastOutActivity > MQTT_KEEPALIVE*1000UL)) {
+		if ((t - lastInActivity > this->keepAlive*1000UL) ||
+		        (t - lastOutActivity > this->keepAlive*1000UL)) {
 			if (pingOutstanding) {
 				this->_state = MQTT_CONNECTION_TIMEOUT;
 				_client->stop();
 				return false;
 			} else {
-				buffer[0] = MQTTPINGREQ;
-				buffer[1] = 0;
-				_client->write(buffer,2);
+				this->buffer[0] = MQTTPINGREQ;
+				this->buffer[1] = 0;
+				_client->write(this->buffer,2);
 				lastOutActivity = t;
 				lastInActivity = t;
 				pingOutstanding = true;
@@ -378,39 +430,39 @@ bool PubSubClient::loop()
 		if (_client->available()) {
 			uint8_t llen;
 			uint16_t len = readPacket(&llen);
+			uint16_t msgId = 0;
+			uint8_t *payload;
 			if (len > 0) {
 				lastInActivity = t;
-				uint8_t type = buffer[0]&0xF0;
+				uint8_t type = this->buffer[0]&0xF0;
 				if (type == MQTTPUBLISH) {
 					if (callback) {
-						uint16_t tl = (buffer[llen+1]<<8)+buffer[llen+2]; /* topic length in bytes */
-						memmove(buffer+llen+2,buffer+llen+3,tl); /* move topic inside buffer 1 byte to front */
-						buffer[llen+2+tl] = 0; /* end the topic as a 'C' string with \x00 */
-						char *topic = (char*) buffer+llen+2;
-						uint8_t *payload;
+						uint16_t tl = (this->buffer[llen+1]<<8)+this->buffer[llen+2]; /* topic length in bytes */
+						memmove(this->buffer+llen+2,this->buffer+llen+3,tl); /* move topic inside buffer 1 byte to front */
+						this->buffer[llen+2+tl] = 0; /* end the topic as a 'C' string with \x00 */
+						char *topic = (char*) this->buffer+llen+2;
 						// msgId only present for QOS>0
-						if ((buffer[0]&0x06) == MQTTQOS1) {
-							uint16_t msgId = 0;
-							msgId = (buffer[llen+3+tl]<<8)+buffer[llen+3+tl+1];
-							payload = buffer+llen+3+tl+2;
+						if ((this->buffer[0]&0x06) == MQTTQOS1) {
+							msgId = (this->buffer[llen+3+tl]<<8)+this->buffer[llen+3+tl+1];
+							payload = this->buffer+llen+3+tl+2;
 							callback(topic,payload,len-llen-3-tl-2);
 
-							buffer[0] = MQTTPUBACK;
-							buffer[1] = 2;
-							buffer[2] = (msgId >> 8);
-							buffer[3] = (msgId & 0xFF);
-							_client->write(buffer,4);
+							this->buffer[0] = MQTTPUBACK;
+							this->buffer[1] = 2;
+							this->buffer[2] = (msgId >> 8);
+							this->buffer[3] = (msgId & 0xFF);
+							_client->write(this->buffer,4);
 							lastOutActivity = t;
 
 						} else {
-							payload = buffer+llen+3+tl;
+							payload = this->buffer+llen+3+tl;
 							callback(topic,payload,len-llen-3-tl);
 						}
 					}
 				} else if (type == MQTTPINGREQ) {
-					buffer[0] = MQTTPINGRESP;
-					buffer[1] = 0;
-					_client->write(buffer,2);
+					this->buffer[0] = MQTTPINGRESP;
+					this->buffer[1] = 0;
+					_client->write(this->buffer,2);
 				} else if (type == MQTTPINGRESP) {
 					pingOutstanding = false;
 				}
@@ -426,12 +478,14 @@ bool PubSubClient::loop()
 
 bool PubSubClient::publish(const char* topic, const char* payload)
 {
-	return publish(topic,(const uint8_t*)payload,strlen(payload),false);
+	return publish(topic,(const uint8_t*)payload, payload ? strnlen(payload, this->bufferSize) : 0,
+	               false);
 }
 
 bool PubSubClient::publish(const char* topic, const char* payload, bool retained)
 {
-	return publish(topic,(const uint8_t*)payload,strlen(payload),retained);
+	return publish(topic,(const uint8_t*)payload, payload ? strnlen(payload, this->bufferSize) : 0,
+	               retained);
 }
 
 bool PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned int plength)
@@ -443,66 +497,74 @@ bool PubSubClient::publish(const char* topic, const uint8_t* payload, unsigned i
                            bool retained)
 {
 	if (connected()) {
-		if (MQTT_MAX_PACKET_SIZE < MQTT_MAX_HEADER_SIZE + 2+strlen(topic) + plength) {
+		if (this->bufferSize < MQTT_MAX_HEADER_SIZE + 2+strnlen(topic, this->bufferSize) + plength) {
 			// Too long
 			return false;
 		}
 		// Leave room in the buffer for header and variable length field
 		uint16_t length = MQTT_MAX_HEADER_SIZE;
-		length = writeString(topic,buffer,length);
+		length = writeString(topic,this->buffer,length);
+
+		// Add payload
 		uint16_t i;
 		for (i=0; i<plength; i++) {
-			buffer[length++] = payload[i];
+			this->buffer[length++] = payload[i];
 		}
+
+		// Write the header
 		uint8_t header = MQTTPUBLISH;
 		if (retained) {
 			header |= 1;
 		}
-		return write(header,buffer,length-MQTT_MAX_HEADER_SIZE);
+		return write(header,this->buffer,length-MQTT_MAX_HEADER_SIZE);
 	}
 	return false;
 }
 
 bool PubSubClient::publish_P(const char* topic, const char* payload, bool retained)
 {
-	return publish_P(topic, (const uint8_t*)payload, strlen(payload), retained);
+	return publish_P(topic, (const uint8_t*)payload, payload ? strnlen(payload, this->bufferSize) : 0,
+	                 retained);
 }
 
 bool PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned int plength,
                              bool retained)
 {
+	uint8_t llen = 0;
+	uint8_t digit;
 	unsigned int rc = 0;
 	uint16_t tlen;
 	unsigned int pos = 0;
 	unsigned int i;
 	uint8_t header;
 	unsigned int len;
+	unsigned int expectedLength;
 
 	if (!connected()) {
 		return false;
 	}
 
-	tlen = strlen(topic);
+	tlen = strnlen(topic, this->bufferSize);
 
 	header = MQTTPUBLISH;
 	if (retained) {
 		header |= 1;
 	}
-	buffer[pos++] = header;
+	this->buffer[pos++] = header;
 	len = plength + 2 + tlen;
 	do {
-		uint8_t digit;
-		digit = len % 128;
-		len = len / 128;
+		digit = len  & 127; //digit = len %128
+		len >>= 7; //len = len / 128
 		if (len > 0) {
 			digit |= 0x80;
 		}
-		buffer[pos++] = digit;
+		this->buffer[pos++] = digit;
+		llen++;
 	} while(len>0);
 
-	pos = writeString(topic,buffer,pos);
+	pos = writeString(topic,this->buffer,pos);
 
-	rc += _client->write(buffer,pos);
+	rc += _client->write(this->buffer,pos);
 
 	for (i=0; i<plength; i++) {
 		rc += _client->write((char)pgm_read_byte_near(payload + i));
@@ -510,7 +572,9 @@ bool PubSubClient::publish_P(const char* topic, const uint8_t* payload, unsigned
 
 	lastOutActivity = millis();
 
-	return rc == tlen + 4 + plength;
+	expectedLength = 1 + llen + 2 + tlen + plength;
+
+	return (rc == expectedLength);
 }
 
 bool PubSubClient::beginPublish(const char* topic, unsigned int plength, bool retained)
@@ -518,13 +582,14 @@ bool PubSubClient::beginPublish(const char* topic, unsigned int plength, bool re
 	if (connected()) {
 		// Send the header and variable length field
 		uint16_t length = MQTT_MAX_HEADER_SIZE;
-		length = writeString(topic,buffer,length);
+		length = writeString(topic,this->buffer,length);
 		uint8_t header = MQTTPUBLISH;
 		if (retained) {
 			header |= 1;
 		}
-		size_t hlen = buildHeader(header, buffer, plength+length-MQTT_MAX_HEADER_SIZE);
-		uint16_t rc = _client->write(buffer+(MQTT_MAX_HEADER_SIZE-hlen),length-(MQTT_MAX_HEADER_SIZE-hlen));
+		size_t hlen = buildHeader(header, this->buffer, plength+length-MQTT_MAX_HEADER_SIZE);
+		uint16_t rc = _client->write(this->buffer+(MQTT_MAX_HEADER_SIZE-hlen),
+		                             length-(MQTT_MAX_HEADER_SIZE-hlen));
 		lastOutActivity = millis();
 		return (rc == (length-(MQTT_MAX_HEADER_SIZE-hlen)));
 	}
@@ -552,12 +617,13 @@ size_t PubSubClient::buildHeader(uint8_t header, uint8_t* buf, uint16_t length)
 {
 	uint8_t lenBuf[4];
 	uint8_t llen = 0;
+	uint8_t digit;
 	uint8_t pos = 0;
 	uint16_t len = length;
 	do {
-		uint8_t digit;
-		digit = len % 128;
-		len = len / 128;
+
+		digit = len  & 127; //digit = len %128
+		len >>= 7; //len = len / 128
 		if (len > 0) {
 			digit |= 0x80;
 		}
@@ -604,10 +670,14 @@ bool PubSubClient::subscribe(const char* topic)
 
 bool PubSubClient::subscribe(const char* topic, uint8_t qos)
 {
+	size_t topicLength = strnlen(topic, this->bufferSize);
+	if (topic == 0) {
+		return false;
+	}
 	if (qos > 1) {
 		return false;
 	}
-	if (MQTT_MAX_PACKET_SIZE < 9 + strlen(topic)) {
+	if (this->bufferSize < 9 + topicLength) {
 		// Too long
 		return false;
 	}
@@ -618,18 +688,22 @@ bool PubSubClient::subscribe(const char* topic, uint8_t qos)
 		if (nextMsgId == 0) {
 			nextMsgId = 1;
 		}
-		buffer[length++] = (nextMsgId >> 8);
-		buffer[length++] = (nextMsgId & 0xFF);
-		length = writeString((char*)topic, buffer,length);
-		buffer[length++] = qos;
-		return write(MQTTSUBSCRIBE|MQTTQOS1,buffer,length-MQTT_MAX_HEADER_SIZE);
+		this->buffer[length++] = (nextMsgId >> 8);
+		this->buffer[length++] = (nextMsgId & 0xFF);
+		length = writeString((char*)topic, this->buffer,length);
+		this->buffer[length++] = qos;
+		return write(MQTTSUBSCRIBE|MQTTQOS1,this->buffer,length-MQTT_MAX_HEADER_SIZE);
 	}
 	return false;
 }
 
 bool PubSubClient::unsubscribe(const char* topic)
 {
-	if (MQTT_MAX_PACKET_SIZE < 9 + strlen(topic)) {
+	size_t topicLength = strnlen(topic, this->bufferSize);
+	if (topic == 0) {
+		return false;
+	}
+	if (this->bufferSize < 9 + topicLength) {
 		// Too long
 		return false;
 	}
@@ -639,19 +713,19 @@ bool PubSubClient::unsubscribe(const char* topic)
 		if (nextMsgId == 0) {
 			nextMsgId = 1;
 		}
-		buffer[length++] = (nextMsgId >> 8);
-		buffer[length++] = (nextMsgId & 0xFF);
-		length = writeString(topic, buffer,length);
-		return write(MQTTUNSUBSCRIBE|MQTTQOS1,buffer,length-MQTT_MAX_HEADER_SIZE);
+		this->buffer[length++] = (nextMsgId >> 8);
+		this->buffer[length++] = (nextMsgId & 0xFF);
+		length = writeString(topic, this->buffer,length);
+		return write(MQTTUNSUBSCRIBE|MQTTQOS1,this->buffer,length-MQTT_MAX_HEADER_SIZE);
 	}
 	return false;
 }
 
 void PubSubClient::disconnect()
 {
-	buffer[0] = MQTTDISCONNECT;
-	buffer[1] = 0;
-	_client->write(buffer,2);
+	this->buffer[0] = MQTTDISCONNECT;
+	this->buffer[1] = 0;
+	_client->write(this->buffer,2);
 	_state = MQTT_DISCONNECTED;
 	_client->flush();
 	_client->stop();
@@ -686,6 +760,8 @@ bool PubSubClient::connected()
 				_client->flush();
 				_client->stop();
 			}
+		} else {
+			return this->_state == MQTT_CONNECTED;
 		}
 	}
 	return rc;
@@ -711,7 +787,7 @@ PubSubClient& PubSubClient::setServer(const char * domain, uint16_t port)
 	this->port = port;
 	return *this;
 }
-// cppcheck-suppress passedByValue
+
 PubSubClient& PubSubClient::setCallback(MQTT_CALLBACK_SIGNATURE)
 {
 	this->callback = callback;
@@ -733,4 +809,39 @@ PubSubClient& PubSubClient::setStream(Stream& stream)
 int PubSubClient::state()
 {
 	return this->_state;
+}
+
+bool PubSubClient::setBufferSize(uint16_t size)
+{
+	if (size == 0) {
+		// Cannot set it back to 0
+		return false;
+	}
+	if (this->bufferSize == 0) {
+		this->buffer = (uint8_t*)malloc(size);
+	} else {
+		uint8_t* newBuffer = (uint8_t*)realloc(this->buffer, size);
+		if (newBuffer != NULL) {
+			this->buffer = newBuffer;
+		} else {
+			return false;
+		}
+	}
+	this->bufferSize = size;
+	return (this->buffer != NULL);
+}
+
+uint16_t PubSubClient::getBufferSize()
+{
+	return this->bufferSize;
+}
+PubSubClient& PubSubClient::setKeepAlive(uint16_t keepAlive)
+{
+	this->keepAlive = keepAlive;
+	return *this;
+}
+PubSubClient& PubSubClient::setSocketTimeout(uint16_t timeout)
+{
+	this->socketTimeout = timeout;
+	return *this;
 }

--- a/drivers/PubSubClient/README.md
+++ b/drivers/PubSubClient/README.md
@@ -13,10 +13,12 @@ Full API documentation is available here: https://pubsubclient.knolleary.net
 ## Limitations
 
  - It can only publish QoS 0 messages. It can subscribe at QoS 0 or QoS 1.
- - The maximum message size, including header, is **128 bytes** by default. This
-   is configurable via `MQTT_MAX_PACKET_SIZE` in `PubSubClient.h`.
+ - The maximum message size, including header, is **256 bytes** by default. This
+   is configurable via `MQTT_MAX_PACKET_SIZE` in `PubSubClient.h` or can be changed
+   by calling `PubSubClient::setBufferSize(size)`.
  - The keepalive interval is set to 15 seconds by default. This is configurable
-   via `MQTT_KEEPALIVE` in `PubSubClient.h`.
+   via `MQTT_KEEPALIVE` in `PubSubClient.h` or can be changed by calling
+   `PubSubClient::setKeepAlive(keepAlive)`.
  - The client uses MQTT 3.1.1 by default. It can be changed to use MQTT 3.1 by
    changing value of `MQTT_VERSION` in `PubSubClient.h`.
 


### PR DESCRIPTION
Changelog: 
  * Add setBufferSize() to override MQTT_MAX_PACKET_SIZE
   * Add setKeepAlive() to override MQTT_KEEPALIVE
   * Add setSocketTimeout() to overide MQTT_SOCKET_TIMEOUT
   * Added check to prevent subscribe/unsubscribe to empty topics
   * Declare wifi mode prior to connect in ESP example
   * Use `strnlen` to avoid overruns
   * Support pre-connected Client objects