### PR TITLE
Rpi gw: Remove stropts.h include

### DIFF
--- a/hal/architecture/Linux/drivers/core/interrupt.cpp
+++ b/hal/architecture/Linux/drivers/core/interrupt.cpp
@@ -30,7 +30,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <stropts.h>
 #include <errno.h>
 #include <sched.h>
 #include "log.h"


### PR DESCRIPTION
It is not used by anything, and causes problems on systems
where this header file does not exist.

This fixes #1431