### PR TITLE
Fix build errors on raspberry pi

### DIFF
--- a/hal/architecture/Linux/drivers/core/config.c
+++ b/hal/architecture/Linux/drivers/core/config.c
@@ -31,6 +31,8 @@ static int _config_create(const char *config_file);
 static int _config_parse_int(char *token, const char *name, int *value);
 static int _config_parse_string(char *token, const char *name, char **value);
 
+struct config conf;
+
 int config_parse(const char *config_file)
 {
 	FILE *fptr;

--- a/hal/architecture/Linux/drivers/core/config.h
+++ b/hal/architecture/Linux/drivers/core/config.h
@@ -36,7 +36,9 @@ struct config {
 	char *soft_hmac_key;
 	char *soft_serial_key;
 	char *aes_key;
-} conf;
+};
+
+extern struct config conf;
 
 int config_parse(const char *config_file);
 void config_cleanup(void);


### PR DESCRIPTION
Build was failing on raspberry pi 3b+ with arch linux:

```
/usr/bin/ld: build/examples_linux/mysgw.o:/home/pi/git/MySensors/./hal/architecture/Linux/drivers/core/config.h:39: multiple definition of `conf'; build/hal/architecture/Linux/drivers/core/config.o:/home/pi/git/MySensors/hal/architecture/Linux/drivers/core/config.h:39: first defined here
```

I posted on the [forum ](https://forum.mysensors.org/topic/11448/config-h-39-first-defined-here/2) but got nothing helpful, so i fixed it myself.
Turns out a variable was being defined in a header file.

My only question is: Why doesn't it error out on raspbian?