### PR TITLE
Add nrf52805 support

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -543,7 +543,11 @@
  * - NRF5_BLE_1MBPS for 1Mbps BLE modulation
  */
 #ifndef MY_NRF5_ESB_MODE
+#ifdef NRF5_250KBPS
 #define MY_NRF5_ESB_MODE (NRF5_250KBPS)
+#else
+#define MY_NRF5_ESB_MODE (NRF5_1MBPS)
+#endif
 #endif
 
 /**

--- a/hal/architecture/NRF5/MyHwNRF5.cpp
+++ b/hal/architecture/NRF5/MyHwNRF5.cpp
@@ -99,7 +99,7 @@ bool hwInit(void)
 	NRF_POWER->TASKS_CONSTLAT = 1;
 
 	// Enable cache on >= NRF52
-#ifndef NRF51
+#if !defined(NRF51) && !defined(NRF52805_XXAA)
 	NRF_NVMC->ICACHECNF = NVMC_ICACHECNF_CACHEEN_Msk;
 #endif
 

--- a/hal/transport/NRF5_ESB/driver/Radio.h
+++ b/hal/transport/NRF5_ESB/driver/Radio.h
@@ -65,7 +65,9 @@ typedef enum {
 typedef enum {
 	NRF5_1MBPS = RADIO_MODE_MODE_Nrf_1Mbit,
 	NRF5_2MBPS = RADIO_MODE_MODE_Nrf_2Mbit,
+#ifdef RADIO_MODE_MODE_Nrf_250Kbit
 	NRF5_250KBPS = RADIO_MODE_MODE_Nrf_250Kbit, // Deprecated!!!
+#endif
 	NRF5_BLE_1MBPS = RADIO_MODE_MODE_Ble_1Mbit,
 } nrf5_mode_e;
 

--- a/hal/transport/NRF5_ESB/driver/Radio_ESB.cpp
+++ b/hal/transport/NRF5_ESB/driver/Radio_ESB.cpp
@@ -547,9 +547,12 @@ static inline uint8_t NRF5_ESB_byte_time()
 		return (3);
 	} else if (MY_NRF5_ESB_MODE == NRF5_2MBPS) {
 		return (2);
-	} else if (MY_NRF5_ESB_MODE == NRF5_250KBPS) {
+	}
+#ifdef NRF5_250KBPS
+	else if (MY_NRF5_ESB_MODE == NRF5_250KBPS) {
 		return (5);
 	}
+#endif
 }
 
 extern "C" {

--- a/hal/transport/NRF5_ESB/driver/Radio_ESB.h
+++ b/hal/transport/NRF5_ESB/driver/Radio_ESB.h
@@ -92,15 +92,19 @@
 	 RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_ADDRESS_BCSTART_Msk |           \
 	 RADIO_SHORTS_ADDRESS_RSSISTART_Msk | RADIO_SHORTS_DISABLED_RSSISTOP_Msk)
 
-// PPI Channels for TX
+/** PPI Channels for TX
+ * Not all NRF5 modules have the same number of PPI channels
+ * For regular PPI, select the highest possible channels
+ */
+#define NRF5_ESB_PPI_LAST_CHANNEL (PPI_CH_NUM - 1)
 #if (NRF5_RADIO_TIMER_IRQN != TIMER0_IRQn)
 // Use two regular PPI channels
-#define NRF5_ESB_PPI_TIMER_START 14
-#define NRF5_ESB_PPI_TIMER_RADIO_DISABLE 15
+#define NRF5_ESB_PPI_TIMER_START (NRF5_ESB_PPI_LAST_CHANNEL - 1)
+#define NRF5_ESB_PPI_TIMER_RADIO_DISABLE (NRF5_ESB_PPI_LAST_CHANNEL)
 #else
 // Use one regular PPI channel and one predefined PPI channel
 #define NRF5_ESB_USE_PREDEFINED_PPI
-#define NRF5_ESB_PPI_TIMER_START 15
+#define NRF5_ESB_PPI_TIMER_START (NRF5_ESB_PPI_LAST_CHANNEL)
 #define NRF5_ESB_PPI_TIMER_RADIO_DISABLE 22
 #endif
 #define NRF5_ESB_PPI_BITS                                                    \


### PR DESCRIPTION
I made few compatibility changes to address assumptions in the code that all NRF52 modules share the same peripherals. 

These shouldn't be breaking changes, but they won't function until this is merged:
- https://github.com/sandeepmistry/arduino-nRF5/pull/442
