### PR TITLE
improve logparser for 2.x log format

### DIFF
--- a/Logparser/logparser.html
+++ b/Logparser/logparser.html
@@ -5,8 +5,8 @@
 		<link rel="stylesheet" href="logparser.css" />
 	</head>
 	<body>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.10/vue.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.12.0/underscore-min.js"></script>
 		<div id="parser">
 			<h4>Paste log from gateway or node here:</h4>
 			<textarea class="form-control" @change="parse" rows="10" v-model="source"></textarea>
@@ -17,15 +17,10 @@
 			<div class="table-responsive">
 				<table class="table table-condensed">
 					<tr>
-						<th>Node Id</th>
-						<th>Child Sensor</th>
-						<th>Command Type</th>
-						<th>Echo Req/Resp</th>
-						<th>Type</th>
-						<th>Payload</th>
+						<th>Log Entry</th>
 						<th>Description</th>
 					</tr>
-					<tr v-for="r in parsed">
+					<tr style="font-family: monospace;" v-for="r in parsed">
 						<td v-for="c in r" v-html="c"></td>
 					</tr>
 				</table>


### PR DESCRIPTION
* prefilters log entries to strip out non-parseable data. This should handle arbitrary log line prefix data (e.g. full or millisecond timestamps, log levels, whitespacing, etc)
* removes old(?) log format assumptions
* output table rows monospace font for improve visual clarity
