### PR TITLE
Improve logparser compatibility

### DIFF
--- a/Logparser/logparser.html
+++ b/Logparser/logparser.html
@@ -5,8 +5,8 @@
 		<link rel="stylesheet" href="logparser.css" />
 	</head>
 	<body>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.10/vue.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.12/vue.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.12.0/underscore-min.js"></script>
 		<div id="parser">
 			<h4>Paste log from gateway or node here:</h4>
 			<textarea class="form-control" @change="parse" rows="10" v-model="source"></textarea>
@@ -25,8 +25,8 @@
 						<th>Payload</th>
 						<th>Description</th>
 					</tr>
-					<tr v-for="r in parsed">
-						<td v-for="c in r" v-html="c"></td>
+					<tr style="font-family: monospace;" v-for="row in parsed">
+						<td v-for="col in row" v-html="col"></td>
 					</tr>
 				</table>
 			</div>


### PR DESCRIPTION
rework of #1468 to maintain compatibility with serial protocol parsing

* output table rows in monospace font to improve visual clarity

for debug log entries:
* prefilters to strip out non-parseable data. This should handle arbitrary log line prefix data (e.g. full or millisecond timestamps, log levels, whitespacing, etc)

IMHO, the table formatting is still not ideal as it's mixing display assumptions about serial protocol vs log entries. As discussed in #1468, will likely need overhaul to handle and display either type in a more generic way, but I'll leave that for another day.