### PR TITLE
Fix nrf5-esb-mode default

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -543,7 +543,7 @@
  * - NRF5_BLE_1MBPS for 1Mbps BLE modulation
  */
 #ifndef MY_NRF5_ESB_MODE
-#ifdef NRF5_250KBPS
+#ifdef RADIO_MODE_MODE_Nrf_250Kbit
 #define MY_NRF5_ESB_MODE (NRF5_250KBPS)
 #else
 #define MY_NRF5_ESB_MODE (NRF5_1MBPS)

--- a/hal/transport/NRF5_ESB/driver/Radio_ESB.cpp
+++ b/hal/transport/NRF5_ESB/driver/Radio_ESB.cpp
@@ -552,7 +552,7 @@ static inline uint8_t NRF5_ESB_byte_time()
 	} else if (MY_NRF5_ESB_MODE == NRF5_2MBPS) {
 		return (2);
 	}
-#ifdef NRF5_250KBPS
+#ifdef RADIO_MODE_MODE_Nrf_250Kbit
 	else if (MY_NRF5_ESB_MODE == NRF5_250KBPS) {
 		return (5);
 	}


### PR DESCRIPTION
This fixes an issue that defaults all NRF5 boards to NRF5_1MBPS, instead of the previous default NRF5_250KBPS. Since radios cannot communicate at different rates, this broke existing deployments (or required users to reflash their entire network at 1MBPS).

First suspected by me https://github.com/mysensors/MySensors/pull/1461#issuecomment-768545052
Confirmed the issue, tested, and confirmed this fix https://github.com/mysensors/MySensors/pull/1455#issuecomment-778833277


