### PR TITLE
Fix: Set CS pin on Linux (RaspberryPI)

### DIFF
--- a/configure
+++ b/configure
@@ -197,25 +197,25 @@ function detect_machine {
             soc="BCM2837"
         fi
         ;;
-    *sun4i*|*Sun4iw1p1*)
+    sun4i|Sun4iw1p1)
         soc="A10"
         ;;
-    *sun5i*|*Sun4iw2p1*)
+    sun5i|Sun4iw2p1)
         soc="A13"
         ;;
-    *Sun4iw2p2*)
+    Sun4iw2p2)
         soc="A12"
         ;;
-    *Sun4iw2p3*)
+    Sun4iw2p3)
         soc="A10s"
         ;;
-    *sun6i*|*Sun8iw1p1*)
+    sun6i|Sun8iw1p1)
         soc="A31"
         ;;
-    *Sun8iw1p2*)
+    Sun8iw1p2)
         soc="A31s"
         ;;
-    *sun7i*|*Sun8iw2p1*)
+    sun7i|Sun8iw2p1)
         soc="A20"
         if [[ $machine == "Banana Pi"* ]]; then
             tp="BananaPi"
@@ -223,25 +223,25 @@ function detect_machine {
             tp="BananaPro"
         fi
         ;;
-    *sun8i*|*Sun8iw7p1*)
+    sun8i|Sun8iw7p1)
         soc="H3"
         ;;
-    *Sun8iw3p1*)
+    Sun8iw3p1)
         soc="A23"
         ;;
-    *Sun8iw5p1*)
+    Sun8iw5p1)
         soc="A33"
         ;;
-    *Sun8iw6p1*)
+    Sun8iw6p1)
         soc="A83t"
         ;;
-    *sun9i*|*Sun9iw1p1*)
+    sun9i|Sun9iw1p1)
         soc="A80"
         ;;
-    *Sun9iw1p2*)
+    Sun9iw1p2)
         soc="A80t"
         ;;
-    *sun50i*|*Sun50iw1p1*)
+    sun50i|Sun50iw1p1)
         soc="A64"
         ;;
     'Generic AM33XX'*)

--- a/hal/architecture/Linux/drivers/BCM/BCM.cpp
+++ b/hal/architecture/Linux/drivers/BCM/BCM.cpp
@@ -34,21 +34,14 @@ BCMClass::~BCMClass()
 	}
 }
 
-uint8_t BCMClass::init()
-{
-	if (!bcm2835_init()) {
-		logError("Failed to initialized bcm2835.\n");
-		exit(1);
-	}
-	initialized = 1;
-
-	return 1;
-}
-
 void BCMClass::pinMode(uint8_t gpio, uint8_t mode)
 {
 	if (!initialized) {
-		init();
+		if (!bcm2835_init()) {
+			logError("Failed to initialized bcm2835.\n");
+			exit(1);
+		}
+		initialized = 1;
 	}
 
 	bcm2835_gpio_fsel(gpio, mode);
@@ -57,7 +50,11 @@ void BCMClass::pinMode(uint8_t gpio, uint8_t mode)
 void BCMClass::digitalWrite(uint8_t gpio, uint8_t value)
 {
 	if (!initialized) {
-		init();
+		if (!bcm2835_init()) {
+			logError("Failed to initialized bcm2835.\n");
+			exit(1);
+		}
+		initialized = 1;
 	}
 
 	bcm2835_gpio_write(gpio, value);
@@ -68,13 +65,12 @@ void BCMClass::digitalWrite(uint8_t gpio, uint8_t value)
 uint8_t BCMClass::digitalRead(uint8_t gpio)
 {
 	if (!initialized) {
-		init();
+		if (!bcm2835_init()) {
+			logError("Failed to initialized bcm2835.\n");
+			exit(1);
+		}
+		initialized = 1;
 	}
 
 	return bcm2835_gpio_lev(gpio);
-}
-
-uint8_t BCMClass::isInitialized()
-{
-	return initialized;
 }

--- a/hal/architecture/Linux/drivers/BCM/BCM.h
+++ b/hal/architecture/Linux/drivers/BCM/BCM.h
@@ -38,12 +38,6 @@ public:
 	 */
 	~BCMClass();
 	/**
-	 * @brief Initializes BCM.
-	 *
-	 * @return 1 if successful, else exits the program.
-	 */
-	uint8_t init();
-	/**
 	 * @brief Configures the specified pin to behave either as an input or an output.
 	 *
 	 * @param gpio The GPIO pin number.
@@ -71,12 +65,6 @@ public:
 	 * @return The GPIO pin number.
 	 */
 	inline uint8_t digitalPinToInterrupt(uint8_t gpio);
-	/**
-	 * @brief Checks if SPI was initialized.
-	 *
-	 * @return 1 if initialized, else 0.
-	 */
-	uint8_t isInitialized();
 
 private:
 	static uint8_t initialized; //!< @brief BCM initialized flag.

--- a/hal/architecture/Linux/drivers/BCM/SPIBCM.cpp
+++ b/hal/architecture/Linux/drivers/BCM/SPIBCM.cpp
@@ -34,9 +34,6 @@ uint8_t SPIBCMClass::initialized = 0;
 void SPIBCMClass::begin()
 {
 	if (!initialized) {
-		if (!BCM.isInitialized()) {
-			BCM.init();
-		}
 		if (!bcm2835_spi_begin()) {
 			logError("You need root privilege to use SPI.\n");
 			exit(1);

--- a/hal/architecture/Linux/drivers/core/SPIDEV.cpp
+++ b/hal/architecture/Linux/drivers/core/SPIDEV.cpp
@@ -37,10 +37,9 @@ SPIDEVClass SPIDEV = SPIDEVClass();
 uint8_t SPIDEVClass::initialized = 0;
 int SPIDEVClass::fd = -1;
 std::string SPIDEVClass::device = SPI_SPIDEV_DEVICE;
-uint8_t SPIDEVClass::mode = SPI_MODE0;
 uint32_t SPIDEVClass::speed = SPI_CLOCK_BASE;
-uint8_t SPIDEVClass::bit_order = MSBFIRST;
-struct spi_ioc_transfer SPIDEVClass::tr = {0,0,0,0,0,8,0,0,0,0};	// 8 bits_per_word, 0 cs_change
+uint32_t SPIDEVClass::speed_temp = SPI_CLOCK_BASE;
+struct spi_ioc_transfer SPIDEVClass::tr = {0,0,0,0,0,8,1,0,0,0};	// 8 bits_per_word, 1 cs_change
 
 SPIDEVClass::SPIDEVClass()
 {
@@ -79,21 +78,15 @@ void SPIDEVClass::end()
 	}
 }
 
-void SPIDEVClass::setBitOrder(uint8_t border)
+void SPIDEVClass::setBitOrder(uint8_t bit_order)
 {
 	pthread_mutex_lock(&spiMutex);
 
 	/*
 	 * bit order
 	 */
-	bit_order = border;
-	int ret = ioctl(fd, SPI_IOC_WR_LSB_FIRST, &bit_order);
-	if (ret == -1) {
-		logError("Can't set SPI bit order.\n");
-		abort();
-	}
-
-	ret = ioctl(fd, SPI_IOC_RD_LSB_FIRST, &bit_order);
+	int lsb_setting = bit_order;
+	int ret = ioctl(fd, SPI_IOC_WR_LSB_FIRST, &lsb_setting);
 	if (ret == -1) {
 		logError("Can't set SPI bit order.\n");
 		abort();
@@ -109,14 +102,7 @@ void SPIDEVClass::setDataMode(uint8_t data_mode)
 	/*
 	 * spi mode
 	 */
-	mode = data_mode;
-	int ret = ioctl(fd, SPI_IOC_WR_MODE, &mode);
-	if (ret == -1) {
-		logError("Can't set SPI mode.\n");
-		abort();
-	}
-
-	ret = ioctl(fd, SPI_IOC_RD_MODE, &mode);
+	int ret = ioctl(fd, SPI_IOC_WR_MODE, &data_mode);
 	if (ret == -1) {
 		logError("Can't set SPI mode.\n");
 		abort();
@@ -127,10 +113,6 @@ void SPIDEVClass::setDataMode(uint8_t data_mode)
 
 void SPIDEVClass::setClockDivider(uint16_t divider)
 {
-	if (divider == 0) {
-		return;
-	}
-
 	pthread_mutex_lock(&spiMutex);
 
 	/*
@@ -138,12 +120,6 @@ void SPIDEVClass::setClockDivider(uint16_t divider)
 	 */
 	speed = SPI_CLOCK_BASE / divider;
 	int ret = ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed);
-	if (ret == -1) {
-		logError("Can't set SPI max speed hz.\n");
-		abort();
-	}
-
-	ret = ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed);
 	if (ret == -1) {
 		logError("Can't set SPI max speed hz.\n");
 		abort();
@@ -219,63 +195,29 @@ void SPIDEVClass::beginTransaction(SPISettings settings)
 	/*
 	 * spi mode
 	 */
-	if (settings.dmode != mode) {
-		mode = settings.dmode;
-
-		ret = ioctl(fd, SPI_IOC_WR_MODE, &mode);
-		if (ret == -1) {
-			logError("Can't set spi mode.\n");
-			abort();
-		}
-
-		ret = ioctl(fd, SPI_IOC_RD_MODE, &mode);
-		if (ret == -1) {
-			logError("Can't set spi mode.\n");
-			abort();
-		}
+	ret = ioctl(fd, SPI_IOC_WR_MODE, &settings.dmode);
+	if (ret == -1) {
+		logError("Can't set spi mode.\n");
+		abort();
 	}
 
-	/*
-	 * speed
-	 */
-	if (settings.clock != speed) {
-		speed = settings.clock;
-
-		ret = ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed);
-		if (ret == -1) {
-			logError("Can't set SPI max speed hz.\n");
-			abort();
-		}
-
-		ret = ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed);
-		if (ret == -1) {
-			logError("Can't set SPI max speed hz.\n");
-			abort();
-		}
-	}
+	// Save the current speed
+	speed_temp = speed;
+	speed = settings.clock;
 
 	/*
 	 * bit order
 	 */
-	if (settings.border != bit_order) {
-		bit_order = settings.border;
-
-		ret = ioctl(fd, SPI_IOC_WR_LSB_FIRST, &bit_order);
-		if (ret == -1) {
-			logError("Can't set SPI bit order.\n");
-			abort();
-		}
-
-		ret = ioctl(fd, SPI_IOC_RD_LSB_FIRST, &bit_order);
-		if (ret == -1) {
-			logError("Can't set SPI bit order.\n");
-			abort();
-		}
+	ret = ioctl(fd, SPI_IOC_WR_LSB_FIRST, &settings.border);
+	if (ret == -1) {
+		logError("Can't set bits per word.\n");
+		abort();
 	}
 }
 
 void SPIDEVClass::endTransaction()
 {
+	speed = speed_temp;
 	pthread_mutex_unlock(&spiMutex);
 }
 
@@ -306,13 +248,8 @@ void SPIDEVClass::init()
 	/*
 	 * spi mode
 	 */
+	uint8_t mode = SPI_MODE0;
 	int ret = ioctl(fd, SPI_IOC_WR_MODE, &mode);
-	if (ret == -1) {
-		logError("Can't set SPI mode.\n");
-		abort();
-	}
-
-	ret = ioctl(fd, SPI_IOC_RD_MODE, &mode);
 	if (ret == -1) {
 		logError("Can't set SPI mode.\n");
 		abort();
@@ -321,14 +258,8 @@ void SPIDEVClass::init()
 	/*
 	 * bits per word
 	 */
-	uint8_t bits = 8;	// 8 bits per word
+	uint8_t bits = 0;	// 0 corresponds to 8 bits per word
 	ret = ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &bits);
-	if (ret == -1) {
-		logError("Can't set SPI bits per word.\n");
-		abort();
-	}
-
-	ret = ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &bits);
 	if (ret == -1) {
 		logError("Can't set SPI bits per word.\n");
 		abort();
@@ -337,13 +268,8 @@ void SPIDEVClass::init()
 	/*
 	 * max speed hz
 	 */
+	speed = SPI_CLOCK_BASE;
 	ret = ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed);
-	if (ret == -1) {
-		logError("Can't set SPI max speed hz.\n");
-		abort();
-	}
-
-	ret = ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed);
 	if (ret == -1) {
 		logError("Can't set SPI max speed hz.\n");
 		abort();
@@ -352,13 +278,8 @@ void SPIDEVClass::init()
 	/*
 	 * bit order
 	 */
-	ret = ioctl(fd, SPI_IOC_WR_LSB_FIRST, &bit_order);
-	if (ret == -1) {
-		logError("Can't set SPI bit order.\n");
-		abort();
-	}
-
-	ret = ioctl(fd, SPI_IOC_RD_LSB_FIRST, &bit_order);
+	int lsb_setting = MSBFIRST;
+	ret = ioctl(fd, SPI_IOC_WR_LSB_FIRST, &lsb_setting);
 	if (ret == -1) {
 		logError("Can't set SPI bit order.\n");
 		abort();

--- a/hal/architecture/Linux/drivers/core/SPIDEV.h
+++ b/hal/architecture/Linux/drivers/core/SPIDEV.h
@@ -199,9 +199,8 @@ private:
 	static uint8_t initialized; //!< @brief SPI initialized flag.
 	static int fd; //!< @brief SPI device file descriptor.
 	static std::string device; //!< @brief Default SPI device.
-	static uint8_t mode; //!< @brief SPI mode.
 	static uint32_t speed; //!< @brief SPI speed.
-	static uint8_t bit_order; //!< @brief SPI bit order.
+	static uint32_t speed_temp; //!< @brief Used when doing transaction.
 	static struct spi_ioc_transfer tr; //!< @brief Auxiliar struct for data transfer.
 
 	static void init();

--- a/hal/transport/RF24/driver/RF24.cpp
+++ b/hal/transport/RF24/driver/RF24.cpp
@@ -44,7 +44,7 @@ uint8_t RF24_spi_txbuff[32+1]
 
 LOCAL void RF24_csn(const bool level)
 {
-#if defined(__linux__)
+#if !defined(MY_RF24_CS_PIN)
 	(void)level;
 #else
 	hwDigitalWrite(MY_RF24_CS_PIN, level);
@@ -522,7 +522,7 @@ LOCAL bool RF24_initialize(void)
 	hwPinMode(MY_RF24_IRQ_PIN,INPUT);
 #endif
 	hwPinMode(MY_RF24_CE_PIN, OUTPUT);
-#if !defined(__linux__)
+#if defined(MY_RF24_CS_PIN)
 	hwPinMode(MY_RF24_CS_PIN, OUTPUT);
 #endif
 	RF24_ce(LOW);

--- a/hal/transport/RF24/driver/RF24.cpp
+++ b/hal/transport/RF24/driver/RF24.cpp
@@ -44,7 +44,7 @@ uint8_t RF24_spi_txbuff[32+1]
 
 LOCAL void RF24_csn(const bool level)
 {
-#if !defined(MY_RF24_CS_PIN)
+#if defined(__linux__)
 	(void)level;
 #else
 	hwDigitalWrite(MY_RF24_CS_PIN, level);
@@ -522,7 +522,7 @@ LOCAL bool RF24_initialize(void)
 	hwPinMode(MY_RF24_IRQ_PIN,INPUT);
 #endif
 	hwPinMode(MY_RF24_CE_PIN, OUTPUT);
-#if defined(MY_RF24_CS_PIN)
+#if !defined(__linux__)
 	hwPinMode(MY_RF24_CS_PIN, OUTPUT);
 #endif
 	RF24_ce(LOW);

--- a/hal/transport/RF24/driver/RF24.cpp
+++ b/hal/transport/RF24/driver/RF24.cpp
@@ -36,7 +36,7 @@ LOCAL uint8_t RF24_NODE_ADDRESS = RF24_BROADCAST_ADDRESS;
 LOCAL RF24_receiveCallbackType RF24_receiveCallback = NULL;
 #endif
 
-#if defined(__linux__)
+#if defined(LINUX_SPI_BCM)
 uint8_t RF24_spi_rxbuff[32+1] ; //SPI receive buffer (payload max 32 bytes)
 uint8_t RF24_spi_txbuff[32+1]
 ; //SPI transmit buffer (payload max 32 bytes + 1 byte for the command)
@@ -44,11 +44,7 @@ uint8_t RF24_spi_txbuff[32+1]
 
 LOCAL void RF24_csn(const bool level)
 {
-#if defined(__linux__)
-	(void)level;
-#else
 	hwDigitalWrite(MY_RF24_CS_PIN, level);
-#endif
 }
 
 LOCAL void RF24_ce(const bool level)
@@ -69,7 +65,7 @@ LOCAL uint8_t RF24_spiMultiByteTransfer(const uint8_t cmd, uint8_t *buf, uint8_t
 	RF24_csn(LOW);
 	// timing
 	delayMicroseconds(10);
-#ifdef __linux__
+#ifdef LINUX_SPI_BCM
 	uint8_t *prx = RF24_spi_rxbuff;
 	uint8_t *ptx = RF24_spi_txbuff;
 	uint8_t size = len + 1; // Add register value to transmit buffer
@@ -522,9 +518,7 @@ LOCAL bool RF24_initialize(void)
 	hwPinMode(MY_RF24_IRQ_PIN,INPUT);
 #endif
 	hwPinMode(MY_RF24_CE_PIN, OUTPUT);
-#if !defined(__linux__)
 	hwPinMode(MY_RF24_CS_PIN, OUTPUT);
-#endif
 	RF24_ce(LOW);
 	RF24_csn(HIGH);
 

--- a/hal/transport/RFM69/driver/new/RFM69_new.cpp
+++ b/hal/transport/RFM69/driver/new/RFM69_new.cpp
@@ -44,7 +44,7 @@
 rfm69_internal_t RFM69;	//!< internal variables
 volatile uint8_t RFM69_irq; //!< rfm69 irq flag
 
-#if defined(__linux__)
+#if defined(LINUX_SPI_BCM)
 // SPI RX and TX buffers (max packet len + 1 byte for the command)
 uint8_t RFM69_spi_rxbuff[RFM69_MAX_PACKET_LEN + 1];
 uint8_t RFM69_spi_txbuff[RFM69_MAX_PACKET_LEN + 1];
@@ -52,11 +52,7 @@ uint8_t RFM69_spi_txbuff[RFM69_MAX_PACKET_LEN + 1];
 
 LOCAL void RFM69_csn(const bool level)
 {
-#if defined(__linux__)
-	(void)level;
-#else
 	hwDigitalWrite(MY_RFM69_CS_PIN, level);
-#endif
 }
 
 LOCAL void RFM69_prepareSPITransaction(void)
@@ -83,7 +79,7 @@ LOCAL uint8_t RFM69_spiMultiByteTransfer(const uint8_t cmd, uint8_t *buf, uint8_
 	RFM69_prepareSPITransaction();
 	RFM69_csn(LOW);
 
-#if defined(__linux__)
+#if defined(LINUX_SPI_BCM)
 	uint8_t *prx = RFM69_spi_rxbuff;
 	uint8_t *ptx = RFM69_spi_txbuff;
 	uint8_t size = len + 1; // Add register value to transmit buffer
@@ -207,10 +203,8 @@ LOCAL bool RFM69_initialise(const uint32_t frequencyHz)
 	RFM69.ATCtargetRSSI = RFM69_RSSItoInternal(MY_RFM69_ATC_TARGET_RSSI_DBM);
 
 	// SPI init
-#if !defined(__linux__)
 	hwDigitalWrite(MY_RFM69_CS_PIN, HIGH);
 	hwPinMode(MY_RFM69_CS_PIN, OUTPUT);
-#endif
 	RFM69_SPI.begin();
 	(void)RFM69_setRadioMode(RFM69_RADIO_MODE_STDBY);
 	// set configuration, encryption is disabled
@@ -257,7 +251,7 @@ LOCAL void RFM69_interruptHandling(void)
 		if (regIrqFlags2 & RFM69_IRQFLAGS2_FIFOLEVEL) {
 			RFM69_prepareSPITransaction();
 			RFM69_csn(LOW);
-#if defined(__linux__)
+#if defined(LINUX_SPI_BCM)
 			char data[RFM69_MAX_PACKET_LEN + 1];   // max packet len + 1 byte for the command
 			data[0] = RFM69_REG_FIFO & RFM69_READ_REGISTER;
 			RFM69_SPI.transfern(data, 3);

--- a/hal/transport/RFM95/driver/RFM95.cpp
+++ b/hal/transport/RFM95/driver/RFM95.cpp
@@ -38,7 +38,7 @@
 rfm95_internal_t RFM95;	//!< internal variables
 volatile uint8_t RFM95_irq; //<! rfm95 irq flag
 
-#if defined(__linux__)
+#if defined(LINUX_SPI_BCM)
 // SPI RX and TX buffers (max packet len + 1 byte for the command)
 uint8_t RFM95_spi_rxbuff[RFM95_MAX_PACKET_LEN + 1];
 uint8_t RFM95_spi_txbuff[RFM95_MAX_PACKET_LEN + 1];
@@ -46,11 +46,7 @@ uint8_t RFM95_spi_txbuff[RFM95_MAX_PACKET_LEN + 1];
 
 LOCAL void RFM95_csn(const bool level)
 {
-#if defined(__linux__)
-	(void)level;
-#else
 	hwDigitalWrite(MY_RFM95_CS_PIN, level);
-#endif
 }
 
 LOCAL uint8_t RFM95_spiMultiByteTransfer(const uint8_t cmd, uint8_t *buf, uint8_t len,
@@ -64,7 +60,7 @@ LOCAL uint8_t RFM95_spiMultiByteTransfer(const uint8_t cmd, uint8_t *buf, uint8_
 #endif
 
 	RFM95_csn(LOW);
-#if defined(__linux__)
+#if defined(LINUX_SPI_BCM)
 	uint8_t *prx = RFM95_spi_rxbuff;
 	uint8_t *ptx = RFM95_spi_txbuff;
 	uint8_t size = len + 1; // Add register value to transmit buffer
@@ -191,10 +187,8 @@ LOCAL bool RFM95_initialise(const uint32_t frequencyHz)
 	RFM95.ATCtargetRSSI = RFM95_RSSItoInternal(RFM95_TARGET_RSSI);
 
 	// SPI init
-#if !defined(__linux__)
 	hwDigitalWrite(MY_RFM95_CS_PIN, HIGH);
 	hwPinMode(MY_RFM95_CS_PIN, OUTPUT);
-#endif
 	RFM95_SPI.begin();
 
 	// Set LoRa mode (during sleep mode)


### PR DESCRIPTION
With the commit 1c33609556e10b15079d8d7452cd1355457bb147 a change was introduced whereby CS is no longer set on Linux. Thus setting the option "--my-rf24-cs-pin=" has no function under Linux.