### PR TITLE
ATmega328PB: deactivate bod during power down

### DIFF
--- a/hal/architecture/AVR/MyHwAVR.cpp
+++ b/hal/architecture/AVR/MyHwAVR.cpp
@@ -101,7 +101,7 @@ void hwPowerDown(const uint8_t wdto)
 	set_sleep_mode(SLEEP_MODE_PWR_DOWN);
 	cli();
 	sleep_enable();
-#if defined(__AVR_ATmega328P__)
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__)
 	sleep_bod_disable();
 #endif
 	// Enable interrupts & sleep until WDT or ext. interrupt


### PR DESCRIPTION
While switching an ATmega328P for an ATmega328PB on one of my test boards I noticed a higher power down current.
During power down the brown out detection doesn't get deactivated on the ATmega328PB, this fixes it.