### PR TITLE
Update hwCPUVoltage to support ATmega1284P

### DIFF
--- a/hal/architecture/AVR/MyHwAVR.cpp
+++ b/hal/architecture/AVR/MyHwAVR.cpp
@@ -289,7 +289,7 @@ bool hwUniqueID(unique_id_t *uniqueID)
 uint16_t hwCPUVoltage(void)
 {
 	// Measure Vcc against 1.1V Vref
-#if defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1284P__)
 	ADMUX = (_BV(REFS0) | _BV(MUX4) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1));
 #elif defined (__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
 	ADMUX = (_BV(MUX5) | _BV(MUX0));


### PR DESCRIPTION
That MCU gets used for example on the MoteinoMEGA board from LowPowerLab and also fixes #1442.
See also: https://lowpowerlab.com/guide/moteino/