### PR TITLE
Mysgw configure: Exit on illegal parameters

### DIFF
--- a/configure
+++ b/configure
@@ -134,7 +134,7 @@ FAILED="${YELLOW}[FAILED]${NO_COLOR}"
 SECTION="${LIGHT_BLUE}[SECTION]${NO_COLOR}"
 
 function die {
-    printf "${ERROR} $1 \n"
+    printf "${RED}${ERROR} $1${NO_COLOR}\n"
     exit $2
 }
 
@@ -451,7 +451,7 @@ for opt do
         elif [[ ${optarg} == "915" ]]; then
             CPPFLAGS="-DMY_RFM69_FREQUENCY=RFM69_915MHZ $CPPFLAGS"
         else
-            echo "[WARNING] Illegal value for --my-rfm69-frequency=${optarg}, ignored"
+            die "Illegal value for --my-rfm69-frequency=${optarg}" 8
         fi
         ;;
     --my-is-rfm69hw*)
@@ -479,7 +479,7 @@ for opt do
         elif [[ ${optarg} == "915" ]]; then
             CPPFLAGS="-DMY_RFM95_FREQUENCY=RFM95_915MHZ $CPPFLAGS"
         else
-            echo "[WARNING] Illegal value for --my-rfm95-frequency=${optarg}, ignored"
+            die "Illegal value for --my-rfm95-frequency=${optarg}" 9
         fi
         ;;
     --my-rfm95-irq-pin=*)
@@ -538,7 +538,7 @@ for opt do
         security_password=${optarg}
         ;;
     *)
-        echo "[WARNING] Unknown option detected:$opt, ignored"
+        die "Unknown option detected: $opt" 10
         ;;
     esac
 done
@@ -638,7 +638,7 @@ elif [[ ${transport_type} == "rfm95" ]]; then
 elif [[ ${transport_type} == "rs485" ]]; then
     CPPFLAGS="-DMY_RS485 $CPPFLAGS"
 else
-    die "Invalid transport type." 3
+    die "Invalid transport type ${transport_type}." 3
 fi
 printf "  ${OK} Transport: ${transport_type}.\n"
 


### PR DESCRIPTION
The user probably made a mistake. Let the user correct the mistake
before continuing.

Ref: https://github.com/mysensors/MySensors/issues/1518

Example output after this change:
$ ./configure --my-transport=laser
[SECTION] Detecting target machine.
  [OK] machine detected: SoC=unknown, Type=unknown, CPU=x86_64.
[SECTION] Checking GPIO Sysfs.
  [WARNING] /sys/class/gpio/export not found.
[SECTION] Detecting SPI driver.
  [WARNING] No supported SPI driver detected. Using SPIDEV.
[SECTION] Gateway configuration.
  [OK] Type: ethernet.
[ERROR] Invalid transport type laser.
$ ./configure --my-mqtt-username=user
[ERROR] Unknown option detected: --my-mqtt-username=user