### PR TITLE
Replace memset() in PJONDefines.h to avoid build warning (#1527)

### DIFF
--- a/hal/transport/PJON/driver/PJONDefines.h
+++ b/hal/transport/PJON/driver/PJONDefines.h
@@ -412,8 +412,9 @@ struct PJONTools {
 
 	static void parse_header(const uint8_t *packet, PJON_Packet_Info &info)
 	{
-		memset(&info, 0, sizeof info);
 		uint8_t index = 0;
+		info = PJON_Packet_Info{};
+
 		info.rx.id = packet[index++];
 		bool extended_length = packet[index] & PJON_EXT_LEN_BIT;
 		info.header = packet[index++];


### PR DESCRIPTION
Fix for Issue #1527

This is a replacement for the `memset(&info, 0, sizeof info)` line, which causes warnings and fails the Toll Gate. Solution is to use `info = PJON_Packet_Info{};` instead.

This solution is taken from the latest PJON version at:
https://github.com/gioblu/PJON/blob/master/src/PJONDefines.h#L398
Latest commit [1be4b15](https://github.com/gioblu/PJON/commit/1be4b1587014180da3393e88c2458bbd0e8e9d22)


