### PR TITLE
Removed a bug in MyMainSAMD.cpp to support ATSAM without USB

### DIFF
--- a/hal/architecture/SAMD/MyMainSAMD.cpp
+++ b/hal/architecture/SAMD/MyMainSAMD.cpp
@@ -24,8 +24,8 @@ extern "C" void __libc_init_array(void);
 int main(void)
 {
 	init();
-#if defined(USBCON)
 	__libc_init_array();
+#if defined(USBCON)
 	USBDevice.init();
 	USBDevice.attach();
 #endif


### PR DESCRIPTION
See: https://forum.mysensors.org/topic/11988/missing-__libc_init_array-wenn-using-samd-without-usb/2