### PR TITLE
Fix building RFM69 gw on 64-bit OS

### DIFF
--- a/hal/transport/RFM69/driver/new/RFM69_new.cpp
+++ b/hal/transport/RFM69/driver/new/RFM69_new.cpp
@@ -278,8 +278,7 @@ LOCAL void RFM69_interruptHandling(void)
 			             RFM69.currentPacket.header.packetLen - 1);
 
 			if (RFM69.currentPacket.header.version >= RFM69_MIN_PACKET_HEADER_VERSION) {
-				RFM69.currentPacket.payloadLen = min(static_cast<uint>
-				                                     (RFM69.currentPacket.header.packetLen - (RFM69_HEADER_LEN - 1)),
+				RFM69.currentPacket.payloadLen = min(RFM69.currentPacket.header.packetLen - (RFM69_HEADER_LEN - 1),
 				                                     RFM69_MAX_PACKET_LEN);
 				RFM69.ackReceived = RFM69_getACKReceived(RFM69.currentPacket.header.controlFlags);
 				RFM69.dataReceived = !RFM69.ackReceived;


### PR DESCRIPTION
Building mysgw with RFM69 driver fails with error on 64-bit OS because there were 2 fixes #1500 and #1551 for the problem (with RFM69_MAX_PACKET_LEN) merged to development branch. Both patches fix the issue by other way and both works when applied separately but building gw is not possible when both are applied... 

I did rollback my fix #1551 to keep the fix #1500 only.