### PR TITLE
Fixed compile error for ESP8266 on newest toolchain

### DIFF
--- a/MySensors.h
+++ b/MySensors.h
@@ -96,11 +96,11 @@
 #define _BV(x) (1<<(x))	//!< _BV
 #endif
 
-#if !defined(min) && !defined(__linux__)
+#if !defined(min) && !defined(__linux__) && !defined(ARDUINO_ARCH_ESP8266)
 #define min(a,b) ((a)<(b)?(a):(b)) //!< min
 #endif
 
-#if !defined(max) && !defined(__linux__)
+#if !defined(max) && !defined(__linux__) && !defined(ARDUINO_ARCH_ESP8266)
 #define max(a,b) ((a)>(b)?(a):(b)) //!< max
 #endif
 

--- a/MySensors.h
+++ b/MySensors.h
@@ -96,11 +96,11 @@
 #define _BV(x) (1<<(x))	//!< _BV
 #endif
 
-#if !defined(min) && !defined(__linux__)
+#if !defined(min) && !defined(__linux__) && !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
 #define min(a,b) ((a)<(b)?(a):(b)) //!< min
 #endif
 
-#if !defined(max) && !defined(__linux__)
+#if !defined(max) && !defined(__linux__) && !defined(ARDUINO_ARCH_ESP8266) && !defined(ARDUINO_ARCH_ESP32)
 #define max(a,b) ((a)>(b)?(a):(b)) //!< max
 #endif
 


### PR DESCRIPTION
Toolchain has template functions max() and min() which are conflicting with the preprocessor defines.