### PR TITLE
Add new type of sensor data - V_TILT

### DIFF
--- a/core/MyMessage.h
+++ b/core/MyMessage.h
@@ -184,6 +184,7 @@ typedef enum {
 	V_VA					= 55,	//!< S_POWER, Apparent power: volt-ampere (VA)
 	V_POWER_FACTOR			= 56,	//!< S_POWER, Ratio of real power to apparent power: floating point value in the range [-1,..,1]
 	V_MULTI_MESSAGE			= 57,	//!< Special type, multiple sensors in one message
+	V_TILT                  = 58   //!< S_COVER, Tilt position (Integer between 0-100)
 } mysensors_data_t;
 #endif
 


### PR DESCRIPTION
This PR adds a new value type V_TILT to the MySensors protocol.

> ID: 36
Label: V_TILT
Description: Represents the tilt angle of blinds or covers with adjustable slats (0–100%).

This new type allows more accurate modeling of façade blinds (external venetian blinds), where tilt and lift are controlled separately.

Example use case:

```
#define CHILD_COVER 1

MyMessage posMsg(CHILD_COVER, V_PERCENTAGE); // cover position
MyMessage tiltMsg(CHILD_COVER, V_TILT);      // lamella tilt

void setup() {
  present(CHILD_COVER, S_COVER);
}

void loop() {
  send(posMsg.set(currentPosition));
  send(tiltMsg.set(currentTilt));
}

void receive(const MyMessage &message) {
  if (message.type == V_PERCENTAGE) {
    int pos = message.getInt();
    // handle open/close
  } else if (message.type == V_TILT) {
    int tilt = message.getInt();
    // handle tilt
  }
}
```

