### PR TITLE
Add STM32WL Support to hal architecture

### DIFF
--- a/hal/architecture/STM32/MyHwSTM32.cpp
+++ b/hal/architecture/STM32/MyHwSTM32.cpp
@@ -477,11 +477,6 @@ static bool hwSleepInit(void)
 	EXTI->PR = EXTI_PR_PR17;
 	NVIC_ClearPendingIRQ(RTC_Alarm_IRQn);
 
-	// Configure EXTI line 17 for RTC Alarm wake-up from STOP mode
-	// Without EXTI, the alarm flag is set but the CPU does not wake
-	EXTI->IMR |= EXTI_IMR_MR17;     // Unmask EXTI line 17
-	EXTI->RTSR |= EXTI_RTSR_TR17;   // Rising edge trigger
-
 	HAL_NVIC_SetPriority(RTC_Alarm_IRQn, 0, 0);
 	HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
 
@@ -807,6 +802,10 @@ static int8_t hwSleepInternal(const uint8_t interrupt1, const uint8_t mode1,
 		// Clear all wake-up flags before entering STOP mode
 #if defined(STM32F1xx)
 		RTC->CRL &= ~RTC_CRL_ALRF;
+		// Configure EXTI line 17 for RTC Alarm wake-up from STOP mode
+		// Without EXTI, the alarm flag is set but the CPU does not wake
+		EXTI->IMR |= EXTI_IMR_MR17;     // Unmask EXTI line 17
+		EXTI->RTSR |= EXTI_RTSR_TR17;   // Rising edge trigger
 		EXTI->PR = EXTI_PR_PR17;
 		NVIC_ClearPendingIRQ(RTC_Alarm_IRQn);
 #else

--- a/hal/architecture/STM32/MyHwSTM32.cpp
+++ b/hal/architecture/STM32/MyHwSTM32.cpp
@@ -364,7 +364,7 @@ uint16_t hwFreeMem(void)
 
 /**
  * @brief Read current RTC counter value (portable)
- * @return 32-bit counter on F1, subsecond-approximated tick on modern STM32
+ * @return Sleep time remaining in ms on modern STM32, time in seconds on F1
  */
 static uint32_t hwRtcGetCounter(void)
 {
@@ -378,7 +378,10 @@ static uint32_t hwRtcGetCounter(void)
 	// Must read date after time to unlock shadow registers
 	RTC_DateTypeDef sDate = {0};
 	HAL_RTC_GetDate(&hrtc, &sDate, RTC_FORMAT_BIN);
-	return (uint32_t)(sTime.Hours * 3600 + sTime.Minutes * 60 + sTime.Seconds);
+	uint32_t prediv_s = hrtc.Init.SynchPrediv;  // e.g. 255
+	uint32_t elapsed_subsec_ms = ((prediv_s - sTime.SubSeconds) * 1000) / (prediv_s + 1);
+	return (uint32_t)(sTime.Hours * 3600000u + sTime.Minutes * 60000u
+	                  + sTime.Seconds * 1000u + elapsed_subsec_ms);
 #endif
 }
 
@@ -946,20 +949,19 @@ static int8_t hwSleepInternal(const uint8_t interrupt1, const uint8_t mode1,
 		// Calculate sleep remaining
 		if (ms > 0) {
 			const uint32_t sleepEndCounter = hwRtcGetCounter();
-			uint32_t elapsedSeconds;
+			uint32_t elapsedMs;
 
 #if defined(STM32F1xx)
-			elapsedSeconds = sleepEndCounter - sleepStartCounter;
+			elapsedMs = (sleepEndCounter - sleepStartCounter)*1000;
 #else
 			// Handle midnight rollover (86400 seconds in a day)
 			if (sleepEndCounter >= sleepStartCounter) {
-				elapsedSeconds = sleepEndCounter - sleepStartCounter;
+				elapsedMs = sleepEndCounter - sleepStartCounter;
 			} else {
-				elapsedSeconds = (86400 - sleepStartCounter) + sleepEndCounter;
+				elapsedMs = (86400000ul - sleepStartCounter) + sleepEndCounter;
 			}
 #endif
 
-			const uint32_t elapsedMs = elapsedSeconds * 1000;
 			sleepRemainingMs = (elapsedMs < ms) ? (ms - elapsedMs) : 0;
 		}
 	}

--- a/hal/architecture/STM32/MyHwSTM32.cpp
+++ b/hal/architecture/STM32/MyHwSTM32.cpp
@@ -264,6 +264,12 @@ bool hwUniqueID(unique_id_t *uniqueID)
 
 uint16_t hwCPUVoltage(void)
 {
+	// For STM32WL, STM32U0 and others that define helper macro
+#if defined(__HAL_ADC_CALC_VREFANALOG_VOLTAGE)
+	analogReadResolution(12);
+	uint32_t vrefint = analogRead(AVREF);
+	return (uint16_t) __HAL_ADC_CALC_VREFANALOG_VOLTAGE(vrefint, LL_ADC_RESOLUTION_12B);
+#else
 #if defined(AVREF) && defined(__HAL_RCC_ADC1_CLK_ENABLE)
 	// Force 12-bit resolution for predictable raw values
 	analogReadResolution(12);
@@ -281,7 +287,8 @@ uint16_t hwCPUVoltage(void)
 		return (uint16_t)((1200UL * 4095UL) / vrefint);
 #endif
 	}
-#endif
+#endif // AVREF and __HAL_RCC . . .
+#endif // __HAL_ADC_CALC_VREFANALOG_VOLTAGE
 
 	return 3300;
 }
@@ -295,6 +302,11 @@ uint16_t hwCPUFrequency(void)
 
 int8_t hwCPUTemperature(void)
 {
+#if defined(__HAL_ADC_CALC_TEMPERATURE) // Use helper macro for STM32WL and some others
+	int32_t VRef = hwCPUVoltage();
+	return (int8_t) __HAL_ADC_CALC_TEMPERATURE(VRef, analogRead(ATEMP), LL_ADC_RESOLUTION_12B );
+#else
+
 	// cppcheck-suppress knownConditionTrueFalse
 	int32_t temp_raw = hwReadInternalTemp();
 
@@ -328,6 +340,7 @@ int8_t hwCPUTemperature(void)
 #endif
 
 	return (int8_t)(((temp - MY_STM32_TEMPERATURE_OFFSET) * 100) / MY_STM32_TEMPERATURE_GAIN);
+#endif // defined __HAL_ADC_CALC_TEMPERATURE
 }
 
 extern "C" caddr_t _sbrk(int incr);
@@ -398,7 +411,9 @@ static bool hwSleepInit(void)
 	__DSB();
 #else
 	// Modern STM32 (F2/F3/F4/F7/L0/L1/L4/L5/G0/G4/H7)
-	__HAL_RCC_PWR_CLK_ENABLE();
+#if !defined(STM32WLxx)
+	__HAL_RCC_PWR_CLK_ENABLE(); // N/A for STM32WL. Clock is alway on.
+#endif // !STM32WLxx
 	HAL_PWR_EnableBkUpAccess();
 #endif
 
@@ -412,7 +427,28 @@ static bool hwSleepInit(void)
 
 	// ---- Select RTC clock source: try LSE, fall back to LSI ----
 	bool useLSE = false;
-
+#ifdef STM32WLxx
+	/* Check if LSE is ready */
+	if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY)) {
+		useLSE = true;
+	} else {
+		/* Check if LSI is ready */
+		if (__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY)) {
+			useLSE = false;
+		} else {
+			// Neither ready — try enabling LSI as fallback
+			__HAL_RCC_LSI_ENABLE();
+			uint32_t timeout = 1000000;
+			while (!__HAL_RCC_GET_FLAG(RCC_FLAG_LSIRDY) && (timeout > 0)) {
+				timeout--;
+			}
+			if (timeout == 0) {
+				return false;
+			}
+			useLSE = false;
+		}
+	}
+#else
 	if ((RCC->BDCR & RCC_BDCR_LSERDY) != 0) {
 		useLSE = true;
 	} else {
@@ -439,8 +475,21 @@ static bool hwSleepInit(void)
 			}
 		}
 	}
-
+#endif
 	// ---- Configure RTC clock source ----
+#ifdef STM32WLxx
+	RCC_PeriphCLKInitTypeDef  periphClk = {0};
+	periphClk.PeriphClockSelection = RCC_PERIPHCLK_RTC;
+	periphClk.RTCClockSelection    = useLSE ? RCC_RTCCLKSOURCE_LSE :  RCC_RTCCLKSOURCE_LSI;
+	if (HAL_RCCEx_PeriphCLKConfig(&periphClk) != HAL_OK) {
+		return false;
+	}
+
+	/* ---- Enable the RTC peripheral clock ---- */
+	__HAL_RCC_RTC_ENABLE();
+	__HAL_RCC_RTCAPB_CLK_ENABLE();
+
+#else
 	uint32_t currentRtcSel = (RCC->BDCR & RCC_BDCR_RTCSEL);
 	uint32_t desiredRtcSel = useLSE ? RCC_BDCR_RTCSEL_0 : RCC_BDCR_RTCSEL_1;
 
@@ -451,7 +500,7 @@ static bool hwSleepInit(void)
 		RCC->BDCR |= desiredRtcSel;
 	}
 	RCC->BDCR |= RCC_BDCR_RTCEN;
-
+#endif
 	// ---- Initialize RTC peripheral ----
 	hrtc.Instance = RTC;
 
@@ -513,6 +562,40 @@ static bool hwSleepInit(void)
 	// Configure interrupt for RTC wake_up timer
 	HAL_NVIC_SetPriority(RTC_TAMP_IRQn, 0, 0);
 	HAL_NVIC_EnableIRQ(RTC_TAMP_IRQn);
+#elif defined(STM32WLxx)
+	hrtc.Init.HourFormat     = RTC_HOURFORMAT_24;
+
+	/* Select prescaler values based on clock source */
+	if (useLSE) {
+		hrtc.Init.AsynchPrediv   = 127;        /* 32768 / 128 = 256 Hz        */
+		hrtc.Init.SynchPrediv    = 255;        /* 256 / 256   = 1 Hz calendar */
+	} else {
+		hrtc.Init.AsynchPrediv   = 127;        /* 32000 / 128 = 250 Hz        */
+		hrtc.Init.SynchPrediv    = 249;        /* 250 / 250   = 1 Hz calendar */
+	}
+
+	hrtc.Init.OutPut         = RTC_OUTPUT_DISABLE;
+	hrtc.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
+	hrtc.Init.OutPutType     = RTC_OUTPUT_TYPE_OPENDRAIN;
+	hrtc.Init.OutPutRemap    = RTC_OUTPUT_REMAP_NONE;
+	hrtc.Init.OutPutPullUp   = RTC_OUTPUT_PULLUP_NONE;
+	hrtc.Init.BinMode        = RTC_BINARY_NONE;
+	if ((RTC->ICSR & RTC_ICSR_INITS) == 0) {
+		if (HAL_RTC_Init(&hrtc) != HAL_OK) {
+			return false;
+		}
+	} else {
+		hrtc.State = HAL_RTC_STATE_READY;
+	}
+
+	// Configure interrupt for RTC wake_up timer
+#if defined(CORE_CM0PLUS) // Dual Core STM32WL
+	HAL_NVIC_SetPriority(RTC_LSECSS_IRQn, 0, 0);
+	HAL_NVIC_EnableIRQ(RTC_LSECSS_IRQn);
+#else // Single Core STM32WL
+	HAL_NVIC_SetPriority(RTC_WKUP_IRQn, 0, 0);
+	HAL_NVIC_EnableIRQ(RTC_WKUP_IRQn);
+#endif // CORE_CM0Plus
 
 #else
 	// ============================================================
@@ -603,9 +686,9 @@ static bool hwSleepConfigureTimer(uint32_t ms)
 	// Enable alarm interrupt in RTC
 	RTC->CRH |= RTC_CRH_ALRIE;
 
-#elif defined(STM32U0xx)
+#elif defined(STM32U0xx)  || defined(STM32WLxx)
 	// ============================================================
-	// STM32U0: Use wake-up timer
+	// STM32U0 & STM32WL: Use wake-up timer
 	// ============================================================
 	// STM32U0 HAL requires a 4th argument: WakeUpAutoClr (auto-clear of wakeup flag)
 
@@ -633,6 +716,11 @@ static bool hwSleepConfigureTimer(uint32_t ms)
 			wakeUpCounter = 0xFFFF;  // Max ~18 hours
 		}
 	}
+
+#if defined(STM32WLxx)
+	// Clear wakeup flag (WUTE + WUTIE) for STM32WL
+	HAL_RTCEx_DeactivateWakeUpTimer(&hrtc);
+#endif
 
 	if (HAL_RTCEx_SetWakeUpTimer_IT(&hrtc, wakeUpCounter, wakeUpClock, 0) != HAL_OK) {
 		return false;
@@ -719,6 +807,21 @@ extern "C" void RTC_TAMP_IRQHandler(void)
 {
 	HAL_RTCEx_WakeUpTimerIRQHandler(&hrtc);
 }
+#elif defined(STM32WLxx)
+
+#if defined(CORE_CM0PLUS)  // Dual processor STM32WL
+extern "C" void RTC_LSECSS_IRQHandler(void)
+#else
+extern "C" void RTC_WKUP_IRQHandler(void)
+#endif
+{
+	HAL_RTCEx_WakeUpTimerIRQHandler(&hrtc);
+}
+extern "C" void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef * /* hrtc */)
+{
+	/* intentionally empty – wake-up is the only action needed */
+}
+
 #else
 extern "C" void RTC_WKUP_IRQHandler(void)
 {
@@ -836,6 +939,7 @@ static int8_t hwSleepInternal(const uint8_t interrupt1, const uint8_t mode1,
 		EXTI->PR = EXTI_PR_PR17;
 #else
 		__HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hrtc, RTC_FLAG_WUTF);
+		HAL_RTC_WaitForSynchro(&hrtc);
 #endif
 		__HAL_PWR_CLEAR_FLAG(PWR_FLAG_WU);
 

--- a/hal/architecture/STM32/README.md
+++ b/hal/architecture/STM32/README.md
@@ -8,6 +8,7 @@ The STM32 HAL enables MySensors to run on a wide range of STM32 microcontrollers
 
 - **STM32F1** series (Cortex-M3)
 - **STM32F4** series (Cortex-M4 with FPU)
+- **STM32WL** series (Cortex-M4 with SX126x radio)
 
 Not tested / implemented:
 - **STM32F0** series (Cortex-M0)
@@ -21,6 +22,7 @@ Tested on:
 - **STM32F103C8 Blue Pill** (72 MHz, 64KB Flash, 20KB RAM)
 - **STM32F401CC Black Pill** (84 MHz, 256KB Flash, 64KB RAM)
 - **STM32F411CE Black Pill** (100 MHz, 512KB Flash, 128KB RAM)
+- **STM32WLE5JC WIO-E5** (48 MHz, 256KB Flash, 64KB RAM)
 
 Should work on any STM32 board supported by the STM32duino core.
 
@@ -226,6 +228,7 @@ Configuration is automatic. EEPROM size can be adjusted in the STM32duino menu o
 - **STM32L1/L4/L5** - RTC wake-up timer, ultra-low power
 - **STM32G0/G4** - RTC wake-up timer
 - **STM32H7** - RTC wake-up timer
+- **STM32WL** - RTC wake-up timer, subsecond resolution, ultra-low power
 
 **Power Consumption:**
 - **STM32F1**: 5-20 µA (STOP mode)

--- a/hal/crypto/generic/MyCryptoGeneric.cpp
+++ b/hal/crypto/generic/MyCryptoGeneric.cpp
@@ -17,6 +17,12 @@
 * version 2 as published by the Free Software Foundation.
 */
 
+#ifdef AES
+#pragma push_macro("AES") // Save STM32 AES Macro
+#undef AES // Allow MySensors AES compilation to proceed 
+#define __STM32_AES_SAVED
+#endif
+
 #include "MyCryptoGeneric.h"
 
 void SHA256HMAC(uint8_t *dest, const uint8_t *key, size_t keyLength, const uint8_t *data,
@@ -43,3 +49,8 @@ void AES128CBCDecrypt(uint8_t *iv, uint8_t *buffer, const size_t dataLength)
 {
 	_aes.cbc_decrypt((byte *)buffer, (byte *)buffer, dataLength / 16, iv);
 }
+
+#ifdef __STM32_AES_SAVED
+#pragma pop_macro("AES") // Restore STM32 AES Macro
+#undef __STM32_AES_SAVED
+#endif


### PR DESCRIPTION
Some Arduino Core STM32WL HAL callouts differ enough from the STM32 processors currently supported by MySensors that it causes compile and function errors.
This PR changes the MySensors STM32 architecture hal to address the STM32WL differences. 

While testing these updates, I identified a latent issue with STM32F1 sleep.  After waking the first time, then going back to sleep, the STM32F1 would not wake from timer again.  This PR also addresses the sleep issue.

The newer STM32 processors have millisecond resolution real time clocks.  This PR adds support for those clocks in the hwGetSleepRemaining function.  Newer processors will return sleep remaining within a few milliseconds.   The STM32F1 only has 1 second resolution.  It's behavior is unchanged, reporting in milliseconds, but only to the nearest second.

Addresses issues #1600 and #1601

I tested these changes on:
     STM32WLE5  (WIO-E5 and WIO-E5-LE modules)
     STM32F411CE (black pill)
     STM32F103 (blue pill)