### PR TITLE
Linux: Fix compilation with EthernetServer.cpp

### DIFF
--- a/hal/architecture/Linux/drivers/core/EthernetServer.cpp
+++ b/hal/architecture/Linux/drivers/core/EthernetServer.cpp
@@ -136,7 +136,7 @@ bool EthernetServer::hasClient()
 	return !new_clients.empty();
 }
 
-EthernetClient EthernetServer::available()
+EthernetClient EthernetServer::accept()
 {
 	if (new_clients.empty()) {
 		return EthernetClient();
@@ -187,7 +187,7 @@ void EthernetServer::_accept()
 	char ipstr[INET_ADDRSTRLEN];
 
 	sin_size = sizeof client_addr;
-	new_fd = accept(sockfd, (struct sockaddr *)&client_addr, &sin_size);
+	new_fd = ::accept(sockfd, (struct sockaddr *)&client_addr, &sin_size);
 	if (new_fd == -1) {
 		if (errno != EAGAIN && errno != EWOULDBLOCK) {
 			logError("accept: %s\n", strerror(errno));

--- a/hal/architecture/Linux/drivers/core/EthernetServer.h
+++ b/hal/architecture/Linux/drivers/core/EthernetServer.h
@@ -72,7 +72,7 @@ public:
 	 *
 	 * @return a EthernetClient object; if no new client has connected, this object will evaluate to false.
 	 */
-	EthernetClient available();
+	EthernetClient accept();
 	/**
 	 * @brief Write a byte to all clients.
 	 *


### PR DESCRIPTION
As of https://github.com/mysensors/MySensors/pull/1585 [MyGatewayTransportEthernet.cpp](https://github.com/mysensors/MySensors/pull/1585/changes#diff-eeff1bb5cd3c9bcf20ea918cfaa75d72c4258e06410be42aa848ff51ec322453) uses `accept()` instead of `available()`.

Therefore for Linux we should provide `accept()`.