### PR TITLE
ethernet tsp fail bug

### DIFF
--- a/core/MySensorsCore.cpp
+++ b/core/MySensorsCore.cpp
@@ -184,11 +184,11 @@ void _begin(void)
 #endif
 
 	// initialise the transport driver
-	if (!gatewayTransportInit()) {
+	// gateway without communication is pointles, so try until it works.
+	while(!gatewayTransportInit()) {
 		setIndication(INDICATION_ERR_INIT_GWTRANSPORT);
 		CORE_DEBUG(PSTR("!MCO:BGN:TSP FAIL\n"));
-		// Nothing more we can do
-		_infiniteLoop();
+		delay(2000);
 	}
 #endif
 


### PR DESCRIPTION
If you start W5100/W5500 ethernet gateway without RJ45 connected, it will hang with TSP FAIL (try to init only once and end).
