### PR TITLE
Add STM32WL Support to SX126x Radio Driver

### DIFF
--- a/MyConfig.h
+++ b/MyConfig.h
@@ -1326,7 +1326,7 @@
 
 /**
  * @def MY_SX126x_RF_ENABLE_PIN
- * @brief Additional Pin to enableantenna circuit
+ * @brief Additional Pin to enable antenna circuit
  *
  * Some modules have an additional RF enable pin (E.G. NUCLEO-WL55JC FE_CTRL3) .
  * Use this to define the enable pin.
@@ -1337,13 +1337,13 @@
  * @def MY_SX126x_RF_SWITCH_PIN
  * @brief Additional Pin to switch antenna circuit between RX and TX, and Idle mode
  *
- * Some modules have additional RF swich pins.  Use this to define and additional pin.
- * Define behavior in different modes using MY_SX126X_RF_SWITCH_IDLE, TX, and RX
+ * Some modules have additional RF switch pins.  Use this to define and additional pin.
+ * Define behavior in different modes using MY_SX126x_RF_SWITCH_IDLE, TX, and RX
  */
-//#define MY_SX126x_RF_SWITCH_PIN (PC5)
+//#define MY_SX126x_RF_SWITCH_PIN (PC4)
 
 /**
- * @def MY_SX126X_RF_SWITCH_IDLE
+ * @def MY_SX126x_RF_SWITCH_IDLE
  * @brief Idle State of additional RF switch pin
  *
  * @ref MY_SX126x_RF_SWITCH_PIN
@@ -1351,7 +1351,7 @@
 //#define MY_SX126x_RF_SWITCH_IDLE LOW
 
 /**
- * @def MY_SX126X_RF_SWITCH_LPTX
+ * @def MY_SX126x_RF_SWITCH_LPTX
  * @brief TX State of additional RF switch pin
  *
  * @ref MY_SX126x_RF_SWITCH_PIN
@@ -1359,7 +1359,7 @@
 //#define MY_SX126x_RF_SWITCH_LPTX LOW
 
 /**
- * @def MY_SX126X_RF_SWITCH_HPTX
+ * @def MY_SX126x_RF_SWITCH_HPTX
  * @brief TX State of additional RF switch pin
  *
  * @ref MY_SX126x_RF_SWITCH_PIN

--- a/MyConfig.h
+++ b/MyConfig.h
@@ -1084,6 +1084,7 @@
  * The following chips are supported by this driver:
  * - Semtech sx1261
  * - Semtech sx1262
+ * - STM32WL series
  * @{
  */
 
@@ -1248,11 +1249,12 @@
 
 /**
  * @def MY_SX126x_VARIANT
- * @brief details if it's a sx1261 or sx1262
+ * @brief details if it's a sx1261, sx1262, or STM32WL
  *
  * - 1: sx1261
  * - 2: sx1262
- * If not set, sx1262 is selected
+ * - 3: STM32WL
+ * If not set, sx1261 is selected
  */
 #if !defined(MY_SX126x_VARIANT)
 #define MY_SX126x_VARIANT (1)
@@ -1307,6 +1309,70 @@
 #ifndef MY_SX126x_MIN_POWER_LEVEL_DBM
 #define MY_SX126x_MIN_POWER_LEVEL_DBM (-3)
 #endif
+
+/**
+ * @def MY_SX126x_ENABLE_ENCRYPTION
+ * @brief Define this to enable software based %AES encryption.
+ *
+ * All nodes and gateway must have this enabled, and all must be personalized with the same %AES
+ * key.
+ * @see @ref personalization
+ *
+ * @warning This driver always sets the initialization vector to 0 so encryption is weak.
+ */
+//#define MY_SX126x_ENABLE_ENCRYPTION
+
+/* Additional Configuration for STM32WL Processors */
+
+/**
+ * @def MY_SX126x_RF_ENABLE_PIN
+ * @brief Additional Pin to enableantenna circuit
+ *
+ * Some modules have an additional RF enable pin (E.G. NUCLEO-WL55JC FE_CTRL3) .
+ * Use this to define the enable pin.
+ */
+//#define MY_SX126x_RF_ENABLE_PIN (PC3)
+
+/**
+ * @def MY_SX126x_RF_SWITCH_PIN
+ * @brief Additional Pin to switch antenna circuit between RX and TX, and Idle mode
+ *
+ * Some modules have additional RF swich pins.  Use this to define and additional pin.
+ * Define behavior in different modes using MY_SX126X_RF_SWITCH_IDLE, TX, and RX
+ */
+//#define MY_SX126x_RF_SWITCH_PIN (PC5)
+
+/**
+ * @def MY_SX126X_RF_SWITCH_IDLE
+ * @brief Idle State of additional RF switch pin
+ *
+ * @ref MY_SX126x_RF_SWITCH_PIN
+ */
+//#define MY_SX126x_RF_SWITCH_IDLE LOW
+
+/**
+ * @def MY_SX126X_RF_SWITCH_LPTX
+ * @brief TX State of additional RF switch pin
+ *
+ * @ref MY_SX126x_RF_SWITCH_PIN
+ */
+//#define MY_SX126x_RF_SWITCH_LPTX LOW
+
+/**
+ * @def MY_SX126X_RF_SWITCH_HPTX
+ * @brief TX State of additional RF switch pin
+ *
+ * @ref MY_SX126x_RF_SWITCH_PIN
+ */
+//#define MY_SX126x_RF_SWITCH_HPTX HIGH
+
+/**
+ * @def MY_SX126x_RF_SWITCH_RX
+ * @brief RX State of additional RF switch pin
+ *
+ * @ref MY_SX126x_RF_SWITCH_PIN
+ */
+//#define MY_SX126x_RF_SWITCH_RX LOW
 
 /** @}*/ // End of SX126xSettingGrpPub group
 
@@ -2536,6 +2602,9 @@
 #ifndef MY_RFM95_ENABLE_ENCRYPTION
 #define MY_RFM95_ENABLE_ENCRYPTION
 #endif
+#ifndef MY_SX126x_ENABLE_ENCRYPTION
+#define MY_SX126x_ENABLE_ENCRYPTION
+#endif
 #endif
 
 /**
@@ -2544,7 +2613,7 @@
  * @brief Helper flag to indicate that some encryption feature is enabled, set automatically
  * @see MY_RF24_ENABLE_ENCRYPTION, MY_RFM69_ENABLE_ENCRYPTION, MY_NRF5_ESB_ENABLE_ENCRYPTION, MY_RFM95_ENABLE_ENCRYPTION
  */
-#if defined(MY_RF24_ENABLE_ENCRYPTION) || defined(MY_RFM69_ENABLE_ENCRYPTION) || defined(MY_NRF5_ESB_ENABLE_ENCRYPTION) || defined(MY_RFM95_ENABLE_ENCRYPTION)
+#if defined(MY_RF24_ENABLE_ENCRYPTION) || defined(MY_RFM69_ENABLE_ENCRYPTION) || defined(MY_NRF5_ESB_ENABLE_ENCRYPTION) || defined(MY_RFM95_ENABLE_ENCRYPTION) || defined(MY_SX126x_ENABLE_ENCRYPTION)
 #define MY_ENCRYPTION_FEATURE
 #endif
 /** @}*/ // End of EncryptionSettingGrpPub group

--- a/examples/STM32WLConfiguration/STM32WLConfiguration.md
+++ b/examples/STM32WLConfiguration/STM32WLConfiguration.md
@@ -1,0 +1,64 @@
+/*
+ * DESCRIPTION
+ * This Document provides some #defines needed to configure common STM32WL modules
+ *
+ * STM32WL series processors use SX126x radios internally, but are more complicated to
+ * configure because they can use either or both of the Highe Power Amplifier and the Low Power Amplifier.
+ * In addition, they use additional pins to configure the RF output of the module
+ */
+
+/*
+ * SEEED WIO-E5
+ * This module has only the High Power Amplifier
+ * It uses the additional RF switch pin, but does not use the enable pin
+ * It supports 868 or 915 MHz
+*/
+#define MY_SX126x_TCXO_VOLTAGE (SX126x_TCXO_1V7)
+#define MY_SX126x_ANT_SWITCH_PIN (PA5)  // P5
+#define MY_SX126x_RF_SWITCH_PIN (PA4) // Enable low or high power for WIO E5 family
+#define MY_SX126x_VARIANT (3)  // It's an STM32WL
+#define MY_SX126x_MAX_POWER_LEVEL_DBM (22) // Max chip capibility.  Check local regulations
+#define MY_SX126x_MIN_POWER_LEVEL_DBM (-9)
+#define MY_SX126x_RF_SWITCH_IDLE LOW
+#define MY_SX126x_RF_SWITCH_RX HIGH
+#define MY_SX126x_RF_SWITCH_HPTX LOW
+
+
+/*
+ * SEEED WIO-E5-LE
+ * This module has only the Low Power Amplifier
+ * It uses the additional RF switch pin, but does not use the enable pin
+ * It only supports 868 or 915 MHz
+ * The lower power consumption of this module makes it a good candidate
+ * for battery powered nodes
+*/
+#define MY_SX126x_TCXO_VOLTAGE (SX126x_TCXO_1V7)
+#define MY_SX126x_ANT_SWITCH_PIN (PA5)  // P5
+#define MY_SX126x_RF_SWITCH_PIN (PA4) // Enable low or high power for WIO E5 family
+#define MY_SX126x_VARIANT (3)  // it's an STM32WL
+#define MY_SX126x_MAX_POWER_LEVEL_DBM (14)
+#define MY_SX126x_MIN_POWER_LEVEL_DBM (-17)
+#define MY_SX126x_RF_SWITCH_IDLE LOW
+#define MY_SX126x_RF_SWITCH_RX HIGH
+#define MY_SX126x_RF_SWITCH_LPTX HIGH
+
+
+/*
+ * STM NUCLEO-WL55JC
+ * This is the original dev board for the STM32WL55
+ * This module has both the Low Power Amplifier and the High Power Amplifier
+ * It uses the additional RF switch pin and the RF enable pin
+ * NUCLEO-WL55JC1 supports high-frequency band
+ * NUCLEO-WL55JC2 supports low-frequency band
+*/
+#define MY_SX126x_TCXO_VOLTAGE (SX126x_TCXO_1V7)
+#define MY_SX126x_ANT_SWITCH_PIN (PC5)  // FE_CTRL2 on schematic
+#define MY_SX126x_RF_SWITCH_PIN (PC4) // FE_CTRL1 on schematic
+#define MY_SX126x_RF_ENABLE_PIN (PC3) // FE_CTRL3 on schematic
+#define MY_SX126x_VARIANT (3)  // it's an STM32WL
+#define MY_SX126x_MAX_POWER_LEVEL_DBM (22) // Max chip capibility. Check local regulations
+#define MY_SX126x_MIN_POWER_LEVEL_DBM (-17)
+#define MY_SX126x_RF_SWITCH_IDLE LOW
+#define MY_SX126x_RF_SWITCH_RX HIGH
+#define MY_SX126x_RF_SWITCH_LPTX HIGH
+#define MY_SX126x_RF_SWITCH_HPTX LOW

--- a/examples/STM32WLConfiguration/STM32WLConfiguration.md
+++ b/examples/STM32WLConfiguration/STM32WLConfiguration.md
@@ -1,64 +1,76 @@
-/*
- * DESCRIPTION
- * This Document provides some #defines needed to configure common STM32WL modules
- *
- * STM32WL series processors use SX126x radios internally, but are more complicated to
- * configure because they can use either or both of the Highe Power Amplifier and the Low Power Amplifier.
- * In addition, they use additional pins to configure the RF output of the module
- */
+**DESCRIPTION**
 
-/*
- * SEEED WIO-E5
- * This module has only the High Power Amplifier
- * It uses the additional RF switch pin, but does not use the enable pin
- * It supports 868 or 915 MHz
-*/
+This Document provides examples of defines needed to configure common STM32WL modules. 
+STM32WL series processors use SX126x radios internally, but are more complicated to 
+configure because they can use either or both of the High Power Amplifier and the Low Power Amplifier. In addition, they need additional pins to configure the RF output of the module.
+
+For the modules below, update the module specific defines in MyConfig.h to match the defines listed in the code block for the module.  You can also paste the code block into your sketch before including MySensors.h.
+Min and Max power levels are the listed as the capability of the radio.  Adjust to your desired settings.
+Network related defines ( frequency, bandwidth, etc) are not included, but still need to be addressed either in MyConfig.h or in the sketch.
+
+
+---
+
+SEEED WIO-E5
+
+- This module has only the High Power Amplifier
+- It uses the additional RF switch pin, but does not use the enable pin
+- It supports 868 or 915 MHz
+
+```
 #define MY_SX126x_TCXO_VOLTAGE (SX126x_TCXO_1V7)
-#define MY_SX126x_ANT_SWITCH_PIN (PA5)  // P5
-#define MY_SX126x_RF_SWITCH_PIN (PA4) // Enable low or high power for WIO E5 family
-#define MY_SX126x_VARIANT (3)  // It's an STM32WL
-#define MY_SX126x_MAX_POWER_LEVEL_DBM (22) // Max chip capibility.  Check local regulations
+#define MY_SX126x_ANT_SWITCH_PIN (PA5)
+#define MY_SX126x_RF_SWITCH_PIN (PA4)
+#define MY_SX126x_VARIANT (3)
+#define MY_SX126x_MAX_POWER_LEVEL_DBM (22) // Max chip capability.  Check local regulations
 #define MY_SX126x_MIN_POWER_LEVEL_DBM (-9)
 #define MY_SX126x_RF_SWITCH_IDLE LOW
 #define MY_SX126x_RF_SWITCH_RX HIGH
 #define MY_SX126x_RF_SWITCH_HPTX LOW
 
+```
 
-/*
- * SEEED WIO-E5-LE
- * This module has only the Low Power Amplifier
- * It uses the additional RF switch pin, but does not use the enable pin
- * It only supports 868 or 915 MHz
- * The lower power consumption of this module makes it a good candidate
- * for battery powered nodes
-*/
+---
+
+SEEED WIO-E5-LE
+
+- This module has only the Low Power Amplifier
+- It uses the additional RF switch pin, but does not use the enable pin
+- It only supports 868 or 915 MHz
+- The lower power consumption of this module makes it a good candidate for battery powered nodes
+
+```
 #define MY_SX126x_TCXO_VOLTAGE (SX126x_TCXO_1V7)
-#define MY_SX126x_ANT_SWITCH_PIN (PA5)  // P5
-#define MY_SX126x_RF_SWITCH_PIN (PA4) // Enable low or high power for WIO E5 family
-#define MY_SX126x_VARIANT (3)  // it's an STM32WL
+#define MY_SX126x_ANT_SWITCH_PIN (PA5)
+#define MY_SX126x_RF_SWITCH_PIN (PA4)
+#define MY_SX126x_VARIANT (3)
 #define MY_SX126x_MAX_POWER_LEVEL_DBM (14)
 #define MY_SX126x_MIN_POWER_LEVEL_DBM (-17)
 #define MY_SX126x_RF_SWITCH_IDLE LOW
 #define MY_SX126x_RF_SWITCH_RX HIGH
 #define MY_SX126x_RF_SWITCH_LPTX HIGH
+```
 
+---
 
-/*
- * STM NUCLEO-WL55JC
- * This is the original dev board for the STM32WL55
- * This module has both the Low Power Amplifier and the High Power Amplifier
- * It uses the additional RF switch pin and the RF enable pin
- * NUCLEO-WL55JC1 supports high-frequency band
- * NUCLEO-WL55JC2 supports low-frequency band
-*/
+STM NUCLEO-WL55JC
+
+- This is the original dev board for the STM32WL55
+- This module has both the Low Power Amplifier and the High Power Amplifier
+- It uses the additional RF switch pin and the RF enable pin
+- NUCLEO-WL55JC1 supports high-frequency band
+- NUCLEO-WL55JC2 supports low-frequency band
+
+```
 #define MY_SX126x_TCXO_VOLTAGE (SX126x_TCXO_1V7)
 #define MY_SX126x_ANT_SWITCH_PIN (PC5)  // FE_CTRL2 on schematic
 #define MY_SX126x_RF_SWITCH_PIN (PC4) // FE_CTRL1 on schematic
 #define MY_SX126x_RF_ENABLE_PIN (PC3) // FE_CTRL3 on schematic
-#define MY_SX126x_VARIANT (3)  // it's an STM32WL
-#define MY_SX126x_MAX_POWER_LEVEL_DBM (22) // Max chip capibility. Check local regulations
+#define MY_SX126x_VARIANT (3)
+#define MY_SX126x_MAX_POWER_LEVEL_DBM (22) // Max chip capability. Check local regulations
 #define MY_SX126x_MIN_POWER_LEVEL_DBM (-17)
 #define MY_SX126x_RF_SWITCH_IDLE LOW
 #define MY_SX126x_RF_SWITCH_RX HIGH
 #define MY_SX126x_RF_SWITCH_LPTX HIGH
 #define MY_SX126x_RF_SWITCH_HPTX LOW
+```

--- a/hal/transport/SX126x/MyTransportSX126x.cpp
+++ b/hal/transport/SX126x/MyTransportSX126x.cpp
@@ -22,8 +22,8 @@
 bool transportInit(void)
 {
 	const bool result = SX126x_initialise();
-#if !defined(MY_GATEWAY_FEATURE) && !defined(MY_SX126x_ATC_MODE_DISABLED)
-	SX126x_setATC(true, SX126x_TARGET_RSSI);
+#if !defined(MY_GATEWAY_FEATURE) && !defined(MY_SX126x_DISABLE_ATC)
+	SX126x_setATC(true, MY_SX126x_ATC_TARGET_DBM);
 #endif
 	return result;
 }

--- a/hal/transport/SX126x/driver/SX126x.cpp
+++ b/hal/transport/SX126x/driver/SX126x.cpp
@@ -33,6 +33,10 @@
 
 //Global status variable
 static sx126x_internal_t SX126x;
+const uint8_t clampLP = 0xC8; // default
+const uint8_t clampHP = 0xDE;  // defaule | 0x1D per datasheet
+bool hpClampFixed = false; // false = default = clampLP is set
+bool useLPA = true;  // true if we are using the LPA, fals for HPA
 
 //helper funcions
 #define SX126x_internalToSNR(internalSNR) internalSNR/4
@@ -88,6 +92,11 @@ static bool SX126x_initialise()
 	hwPinMode(MY_SX126x_ANT_SWITCH_PIN, OUTPUT);
 	hwDigitalWrite(MY_SX126x_ANT_SWITCH_PIN, LOW);
 	SX126x_DEBUG(PSTR("SX126x:INIT:ASWPIN=%u\n"), MY_SX126x_ANT_SWITCH_PIN);
+#endif
+#ifdef MY_SX126x_RF_SWITCH_PIN
+	hwPinMode(MY_SX126x_RF_SWITCH_PIN, OUTPUT);
+	hwDigitalWrite(MY_SX126x_RF_SWITCH_PIN, MY_SX126x_RF_SWITCH_IDLE);
+	SX126x_DEBUG(PSTR("SX126x:INIT:RFWPIN=%u MY_SX126x_RF_SWITCH_IDLE\n"), MY_SX126x_RF_SWITCH_PIN);
 #endif
 
 
@@ -211,9 +220,6 @@ static void SX126x_handle()
 			//Transmission done
 			if (irqStatus & SX126x_IRQ_TX_DONE) {
 				SX126x.txComplete = true;
-#ifdef MY_SX126x_ANT_SWITCH_PIN
-				hwDigitalWrite(MY_SX126x_ANT_SWITCH_PIN, LOW);
-#endif
 				SX126x_rx();
 			}
 
@@ -240,7 +246,7 @@ static void SX126x_handle()
 					                     !SX126x.currentPacket.header.controlFlags.fields.ackRequested;
 					SX126x.dataReceived = !SX126x.ackReceived;
 				}
-				//SX126x_rx();
+				SX126x_rx(); // Go to RX for next message
 			}
 
 			//CAD done
@@ -289,6 +295,16 @@ static void SX126x_wakeUp()
 static void SX126x_standBy()
 {
 	SX126x_deviceReady();
+#ifdef MY_SX126x_ANT_SWITCH_PIN
+	hwDigitalWrite(MY_SX126x_ANT_SWITCH_PIN, LOW);
+#endif
+#ifdef MY_SX126x_RF_SWITCH_PIN
+	hwDigitalWrite(MY_SX126x_RF_SWITCH_PIN, MY_SX126x_RF_SWITCH_IDLE);
+#endif
+#ifdef MY_SX126x_RF_ENABLE_PIN
+	hwDigitalWrite(MY_SX126x_RF_ENABLE_PIN, LOW);
+#endif
+
 	SX126x_sendCommand(SX126x_SET_STANDBY, SX126x_STDBY_RC);
 	SX126x.radioMode = SX126x_MODE_STDBY_RC;
 }
@@ -318,31 +334,49 @@ static void SX126x_sleep(void)
 
 static bool SX126x_txPower(sx126x_powerLevel_t power)
 {
-	sx126x_paSettings_t paSettings = {};
-#if (SX126x_VARIANT == 1)
-	paSettings.fields.hpMax = 0x00;
-	paSettings.fields.deviceSel = 0x01;
-	if (power >= 15) {
-		paSettings.fields.paDutyCycle = 0x06;
-	} else {
-		paSettings.fields.paDutyCycle = 0x04;
-	}
-	if (power >=14) {
-		power = 14;
-	} else if (power <= -3) {
-		power = -3;
-	}
-	SX126x_sendRegister(SX126x_REG_OCP, 0x18); // 80mA over current protection
-#elif (SX126xVARIANT == 2)
-	paSettings.fields.deviceSel = 0x00;
-	power = constrain(power, -9, 22);
-	power = constrain(power, MY_SX126x_MIN_POWER_LEVEL_DBM, MY_SX126x_MAX_POWER_LEVEL_DBM);
-	SX126x.powerLevel = power;
-	paSettings.fields.paDutyCycle = 0x04;
-	paSettings.fields.hpMax = 0x07;
-	SX126x_sendRegister(SX126x_REG_OCP, 0x38); // 160mA over current protection
-#endif
+	power = constrain(power, MY_SX126x_MIN_POWER_LEVEL_DBM,
+	                  MY_SX126x_MAX_POWER_LEVEL_DBM); // Constarin to user desired settings
 
+	// Determine Power Amplifier to use
+	if((hasLPA && hasHPA) && (power > 14)) {
+		useLPA = false;
+	} else if (!hasLPA && hasHPA) {
+		useLPA = false;
+	} else {
+		useLPA = true;
+	}
+
+	sx126x_paSettings_t paSettings = { 0, 0, 0, 0x01 };
+	paSettings.fields.paLut = 0x01; // TODO:  I think this is redundant
+	if (useLPA) { // use LP PA
+		power = constrain(power, -17, 15); // Constrain to PA capability
+		paSettings.fields.hpMax = 0x00;
+		paSettings.fields.deviceSel = 0x01;
+		// Power Optimizations
+		if (power == 15) {
+			paSettings.fields.paDutyCycle = 0x06;
+			power = 14; // Power setting required to get desired output power
+		} else {
+			paSettings.fields.paDutyCycle = 0x04;
+		}
+		if(hpClampFixed) {
+			SX126x_sendRegister(0x08D8, clampLP);  // turn off hpClampFix if using LP PA
+			hpClampFixed = false;
+		}
+		SX126x_sendRegister(SX126x_REG_OCP, 0x18); // 80mA over current protection
+	} else { // use HP PA
+		power = constrain(power, -9, 22);
+		paSettings.fields.hpMax = 0x07;
+		paSettings.fields.deviceSel = 0x00;
+		paSettings.fields.paDutyCycle = 0x04;
+		if(!hpClampFixed) {
+			SX126x_sendRegister(0x08D8, clampHP);  // turn on hpClampFix
+			hpClampFixed = true;
+		}
+		// Future effort: Add additional PA optimizations here
+
+		SX126x_sendRegister(SX126x_REG_OCP, 0x38); // 160mA over current protection
+	}
 	SX126x_sendCommand(SX126x_SET_PACONFIG, paSettings.values, 4);
 	sx126x_txSettings_t txSettings;
 	txSettings.fields.power = power;
@@ -540,14 +574,16 @@ static bool SX126x_sendWithRetry(const uint8_t recipient, const void *buffer,
 			doYield();
 		}
 		SX126x_DEBUG(PSTR("!SX126x:SWR:NACK\n"));
-		const uint32_t enterCSMAMS = hwMillis();
+		const uint32_t enterCSMAMS = hwMillis(); // wait for a clear channel
 		const uint16_t randDelayCSMA = start % 100;
 		while (hwMillis() - enterCSMAMS < randDelayCSMA) {
 			doYield();
 		}
-	}
-	if (SX126x.ATCenabled) {
-		SX126x_txPower(SX126x.powerLevel + 2); //increase power, maybe we are far away from gateway
+
+		if (SX126x.ATCenabled) {
+			SX126x_txPower(SX126x.powerLevel + 2); //increase power, maybe we are far away from gateway
+		}
+		return false;
 	}
 	return false;
 }
@@ -615,18 +651,43 @@ static void SX126x_readBuffer(const uint8_t offset, uint8_t *buffer, const uint8
 
 static void SX126x_tx()
 {
+#ifdef MY_SX126x_ANT_SWITCH_PIN
+	hwDigitalWrite(MY_SX126x_ANT_SWITCH_PIN, HIGH);
+#endif
+#ifdef MY_SX126x_RF_SWITCH_PIN
+	if (useLPA) {
+#ifdef MY_SX126x_RF_SWITCH_LPTX
+		hwDigitalWrite(MY_SX126x_RF_SWITCH_PIN, MY_SX126x_RF_SWITCH_LPTX);
+#endif
+	} else {
+#ifdef MY_SX126x_RF_SWITCH_HPTX)
+		hwDigitalWrite(MY_SX126x_RF_SWITCH_PIN, MY_SX126x_RF_SWITCH_HPTX);
+#endif
+	}
+#endif
+#ifdef MY_SX126x_RF_ENABLE_PIN
+	hwDigitalWrite(MY_SX126x_RF_ENABLE_PIN, HIGH);
+#endif
 	uint8_t timeout[3] = { 0x00, 0x00, 0x00 }; //no timeout
 	SX126x_deviceReady();
 	SX126x_setIrqMask(SX126x_IRQ_TX_DONE);
 	SX126x_sendCommand(SX126x_SET_TX, timeout, 3);
-#ifdef MY_SX126x_ANT_SWITCH_PIN
-	hwDigitalWrite(MY_SX126x_ANT_SWITCH_PIN, HIGH);
-#endif
+	SX126x_busy(); // Wait till ramp up is complete
 	SX126x.radioMode = SX126x_MODE_TX;
 }
 
 static void SX126x_rx()
 {
+#ifdef MY_SX126x_ANT_SWITCH_PIN
+	hwDigitalWrite(MY_SX126x_ANT_SWITCH_PIN, LOW);
+#endif
+#ifdef MY_SX126x_RF_SWITCH_PIN
+	hwDigitalWrite(MY_SX126x_RF_SWITCH_PIN, MY_SX126x_RF_SWITCH_RX);
+#endif
+#ifdef MY_SX126x_RF_ENABLE_PIN
+	hwDigitalWrite(MY_SX126x_RF_ENABLE_PIN, HIGH);
+#endif
+
 	uint8_t timeout[3] = { 0x00, 0x00, 0x00 }; //no timeout, go into standby after reception
 	SX126x_deviceReady();
 	SX126x_setIrqMask(SX126x_IRQ_RX_DONE | SX126x_IRQ_CRC_ERROR | SX126x_IRQ_RX_TX_TIMEOUT);
@@ -722,7 +783,7 @@ static bool SX126x_cad()
 static bool SX126x_packetAvailable()
 {
 	if (SX126x.radioMode != SX126x_MODE_RX && SX126x.radioMode != SX126x_MODE_TX) {
-		//if we are not sending or already in receive, go into receive;
+		//if we are not sending or not already in receive, go into receive;
 		SX126x_rx();
 	}
 	return SX126x.dataReceived;
@@ -775,7 +836,6 @@ static void SX126x_ATC()
 	int8_t delta;
 	sx126x_powerLevel_t newPowerLevel;
 	delta = SX126x.targetRSSI - SX126x_internalToRSSI(SX126x.currentPacket.ACK.RSSI);
-	sx126x_powerLevel_t oldPowerLevel = SX126x.powerLevel;
 	newPowerLevel = SX126x.powerLevel + delta / 2;
 	newPowerLevel = constrain(newPowerLevel, MY_SX126x_MIN_POWER_LEVEL_DBM,
 	                          MY_SX126x_MAX_POWER_LEVEL_DBM);
@@ -784,7 +844,7 @@ static void SX126x_ATC()
 	             SX126x.targetRSSI,
 	             newPowerLevel
 	            );
-	if (newPowerLevel != oldPowerLevel) {
+	if (newPowerLevel != SX126x.powerLevel) {
 		SX126x_txPower(newPowerLevel);
 	}
 }
@@ -862,8 +922,8 @@ static uint8_t SX126x_getTxPowerPercent(void)
 static bool SX126x_setTxPowerPercent(const uint8_t newPowerPercent)
 {
 	const sx126x_powerLevel_t newPowerLevel = static_cast<sx126x_powerLevel_t>
-	        (MY_SX126x_MIN_POWER_LEVEL_DBM + (MY_SX126x_MAX_POWER_LEVEL_DBM
-	                - MY_SX126x_MIN_POWER_LEVEL_DBM) * (newPowerPercent / 100.0f));
+	    (MY_SX126x_MIN_POWER_LEVEL_DBM + (MY_SX126x_MAX_POWER_LEVEL_DBM
+	                                      - MY_SX126x_MIN_POWER_LEVEL_DBM) * (newPowerPercent / 100.0f));
 	SX126x_DEBUG(PSTR("SX126x:SPP:PCT=%u,TX LEVEL=%n\n"), newPowerPercent, newPowerLevel);
 	return SX126x_txPower(newPowerLevel);
 }

--- a/hal/transport/SX126x/driver/SX126x.cpp
+++ b/hal/transport/SX126x/driver/SX126x.cpp
@@ -57,7 +57,7 @@ static bool SX126x_initialise()
 	SX126x_DEBUG(PSTR("SX126x:INIT\n"));
 #if !defined(SUBGHZSPI_BASE)
 #if defined(MY_SX126x_POWER_PIN)
-	hwPinMode(MY_SX_126x_POWER_PIN, OUTPUT);
+	hwPinMode(MY_SX126x_POWER_PIN, OUTPUT);
 	SX126x_powerUp();
 	SX126x_DEBUG(PSTR("SX126x:INIT:PWRPIN=%u\n"), MY_SX126x_POWER_PIN);
 #endif
@@ -346,8 +346,8 @@ static bool SX126x_txPower(sx126x_powerLevel_t power)
 		useLPA = true;
 	}
 
-	sx126x_paSettings_t paSettings = { 0, 0, 0, 0x01 };
-	paSettings.fields.paLut = 0x01; // TODO:  I think this is redundant
+	sx126x_paSettings_t paSettings{ };
+	paSettings.fields.paLut = 0x01;
 	if (useLPA) { // use LP PA
 		power = constrain(power, -17, 15); // Constrain to PA capability
 		paSettings.fields.hpMax = 0x00;
@@ -383,7 +383,7 @@ static bool SX126x_txPower(sx126x_powerLevel_t power)
 	txSettings.fields.rampTime = RADIO_RAMP_200_US;
 	SX126x_sendCommand(SX126x_SET_TXPARAMS, txSettings.values, 2);
 	SX126x.powerLevel = power;
-	SX126x_DEBUG(PSTR("SX126x:PTC:LEVEL=%d"), SX126x.powerLevel);
+	SX126x_DEBUG(PSTR("SX126x:PTC:LEVEL=%d\n"), SX126x.powerLevel);
 	return true;
 }
 
@@ -421,20 +421,25 @@ static void SX126x_readCommand(sx126x_commands_t command, uint8_t *buffer, uint1
 	SX126x_busy();
 }
 
-void SX126x_sendRegisters(uint16_t address, uint8_t *buffer, uint16_t size)
+static void SX126x_sendRegisters(uint16_t address, uint8_t *buffer, uint16_t size)
 {
 	SX126x_busy();
 	SET_SX126x_CS_LOW();
-#if defined(SUBGHZSPI_BASE)
-	SX126x_SPI.transfer(NULL, buffer, size);
-#else
-	SX126x_SPI.transferBytes(NULL, buffer, size);
-#endif
+
+	// SX126x write-register command (0x0D)
+	SX126x_SPI.transfer(SX126x_WRITE_REGISTER);
+	SX126x_SPI.transfer((uint8_t)(address >> 8));
+	SX126x_SPI.transfer((uint8_t)(address & 0xFF));
+
+	for (uint16_t i = 0; i < size; i++) {
+		SX126x_SPI.transfer(buffer[i]);
+	}
+
 	SET_SX126x_CS_HIGH();
 	SX126x_busy();
 }
 
-void SX126x_sendRegister(uint16_t address, uint8_t value)
+static void SX126x_sendRegister(uint16_t address, uint8_t value)
 {
 	SX126x_sendRegisters(address, &value, 1);
 }
@@ -583,7 +588,6 @@ static bool SX126x_sendWithRetry(const uint8_t recipient, const void *buffer,
 		if (SX126x.ATCenabled) {
 			SX126x_txPower(SX126x.powerLevel + 2); //increase power, maybe we are far away from gateway
 		}
-		return false;
 	}
 	return false;
 }
@@ -858,16 +862,16 @@ static void SX126x_setATC(bool onOff, int8_t targetRSSI)
 void SX126x_powerUp()
 {
 #ifdef MY_SX126x_POWER_PIN
-	hwDigitalWrite(SX126x_POWER_PIN, HIGH);
-	SX126x_DEBUG(PSTR("SX126x:PWU\n");
+	hwDigitalWrite(MY_SX126x_POWER_PIN, HIGH);
+	SX126x_DEBUG(PSTR("SX126x:PWU\n"));
 #endif
 }
 
 void SX126x_powerDown()
 {
 #ifdef MY_SX126x_POWER_PIN
-	hwDigitalWrite(SX126x_POWER_PIN, LOW);
-	SX126x_DEBUG(PSTR("SX126x:PWD\n");
+	hwDigitalWrite(MY_SX126x_POWER_PIN, LOW);
+	SX126x_DEBUG(PSTR("SX126x:PWD\n"));
 #endif
 }
 

--- a/hal/transport/SX126x/driver/SX126x.cpp
+++ b/hal/transport/SX126x/driver/SX126x.cpp
@@ -51,6 +51,7 @@ static bool SX126x_initialise()
 {
 	// setting pin modes
 	SX126x_DEBUG(PSTR("SX126x:INIT\n"));
+#if !defined(SUBGHZSPI_BASE)
 #if defined(MY_SX126x_POWER_PIN)
 	hwPinMode(MY_SX_126x_POWER_PIN, OUTPUT);
 	SX126x_powerUp();
@@ -64,7 +65,18 @@ static bool SX126x_initialise()
 	hwPinMode(MY_SX126x_IRQ_PIN, INPUT);
 	SX126x_DEBUG(PSTR("SX126x:INIT:IRQPIN=%u\n"), MY_SX126x_IRQ_PIN);
 #endif
-#if defined(MY_SX126x_RESET_PIN)
+#if !defined(__linux__)
+	hwDigitalWrite(MY_SX126x_CS_PIN, HIGH);
+	hwPinMode(MY_SX126x_CS_PIN, OUTPUT);
+#endif
+#endif // !SUBGHZSPI_BASE
+#if defined(SUBGHZSPI_BASE)
+	SubGhz.setResetActive(true);
+	delay(SX126x_POWERUP_DELAY_MS);
+	SubGhz.setResetActive(false);
+	delay(SX126x_POWERUP_DELAY_MS);
+	SX126x_DEBUG(PSTR("SX126x:INIT:RST INTERNAL\n"));
+#elif defined(MY_SX126x_RESET_PIN)
 	hwPinMode(MY_SX126x_RESET_PIN, OUTPUT);
 	hwDigitalWrite(MY_SX126x_RESET_PIN, LOW);
 	delay(SX126x_POWERUP_DELAY_MS);
@@ -78,10 +90,7 @@ static bool SX126x_initialise()
 	SX126x_DEBUG(PSTR("SX126x:INIT:ASWPIN=%u\n"), MY_SX126x_ANT_SWITCH_PIN);
 #endif
 
-#if !defined(__linux__)
-	hwDigitalWrite(MY_SX126x_CS_PIN, HIGH);
-	hwPinMode(MY_SX126x_CS_PIN, OUTPUT);
-#endif
+
 	SX126x_SPI.begin();
 
 	SX126x.address = SX126x_BROADCAST_ADDRESS;
@@ -156,7 +165,11 @@ static bool SX126x_initialise()
 	SX126x_setPacketParameters(0xFF);
 
 	// disable and clear all interrupts
+#if defined(SUBGHZSPI_BASE)
+	SubGhz.attachInterrupt(SX126x_interruptHandler);
+#else
 	attachInterrupt(MY_SX126x_IRQ_NUM, SX126x_interruptHandler, RISING);
+#endif
 	SX126x_setIrqMask(SX126x_IRQ_NONE);
 	SX126x_clearIrq(SX126x_IRQ_ALL);
 
@@ -172,15 +185,20 @@ static bool SX126x_initialise()
 
 static void SX126x_interruptHandler()
 {
+#if defined(SUBGHZSPI_BASE)
+	SubGhz.disableInterrupt();  // prevent level-triggered re-fire
+#else
 	noInterrupts();
+#endif
 	SX126x.irqFired = true;
-	SX126x.radioMode = SX126x_MODE_STDBY_RC;
+#if !defined(SUBGHZSPI_BASE)
 	interrupts();
+#endif
 }
 
 static void SX126x_handle()
 {
-#ifdef MY_SX126x_IRQ_PIN
+#if defined(MY_SX126x_IRQ_PIN) || defined(SUBGHZSPI_BASE)
 	if (SX126x.irqFired) {
 #endif
 		uint32_t irqStatus = SX126x_IRQ_NONE;
@@ -239,8 +257,12 @@ static void SX126x_handle()
 
 			SX126x_clearIrq(SX126x_IRQ_ALL);
 			SX126x.irqFired = false;
+#if defined(SUBGHZSPI_BASE)
+			SubGhz.clearPendingInterrupt();
+			SubGhz.enableInterrupt();
+#endif
 		}
-#ifdef MY_SX126x_IRQ_PIN
+#if defined(MY_SX126x_IRQ_PIN) || defined(SUBGHZSPI_BASE)
 	}
 #endif
 }
@@ -257,10 +279,10 @@ void SX126x_deviceReady(void)
 static void SX126x_wakeUp()
 {
 	noInterrupts();
-	hwDigitalWrite(MY_SX126x_CS_PIN, LOW);
+	SET_SX126x_CS_LOW();
 	SX126x_SPI.transfer(SX126x_GET_STATUS);
 	SX126x_SPI.transfer(0x00);
-	hwDigitalWrite(MY_SX126x_CS_PIN, HIGH);
+	SET_SX126x_CS_HIGH();
 	interrupts();
 }
 
@@ -273,7 +295,10 @@ static void SX126x_standBy()
 
 static void SX126x_busy(void)
 {
-#ifdef MY_SX126x_BUSY_PIN
+#if defined(SUBGHZSPI_BASE)
+	while (SubGhz.isBusy()) {
+	}
+#elif defined(MY_SX126x_BUSY_PIN)
 	while (hwDigitalRead(MY_SX126x_BUSY_PIN) == 1) {
 	}
 #else
@@ -331,12 +356,12 @@ static bool SX126x_txPower(sx126x_powerLevel_t power)
 static void SX126x_sendCommand(sx126x_commands_t command, uint8_t *buffer, uint16_t size)
 {
 	SX126x_busy();
-	hwDigitalWrite(MY_SX126x_CS_PIN, LOW);
+	SET_SX126x_CS_LOW();
 	SX126x_SPI.transfer(command);
 	for (uint16_t i = 0; i < size; i++) {
 		SX126x_SPI.transfer(buffer[i]);
 	}
-	hwDigitalWrite(MY_SX126x_CS_PIN, HIGH);
+	SET_SX126x_CS_HIGH();
 	if (command != SX126x_SET_SLEEP) {
 		SX126x_busy();
 	}
@@ -352,22 +377,26 @@ static void SX126x_sendCommand(sx126x_commands_t command, uint8_t parameter)
 static void SX126x_readCommand(sx126x_commands_t command, uint8_t *buffer, uint16_t size)
 {
 	SX126x_busy();
-	hwDigitalWrite(MY_SX126x_CS_PIN, LOW);
+	SET_SX126x_CS_LOW();
 	SX126x_SPI.transfer(command);
 	SX126x_SPI.transfer(0x00);
 	for (uint16_t i = 0; i < size; i++) {
 		buffer[i] = SX126x_SPI.transfer(0x00);
 	}
-	hwDigitalWrite(MY_SX126x_CS_PIN, HIGH);
+	SET_SX126x_CS_HIGH();
 	SX126x_busy();
 }
 
 void SX126x_sendRegisters(uint16_t address, uint8_t *buffer, uint16_t size)
 {
 	SX126x_busy();
-	hwDigitalWrite(MY_SX126x_CS_PIN, LOW);
-	SX126x_SPI.transfer(buffer, size);
-	hwDigitalWrite(MY_SX126x_CS_PIN, HIGH);
+	SET_SX126x_CS_LOW();
+#if defined(SUBGHZSPI_BASE)
+	SX126x_SPI.transfer(NULL, buffer, size);
+#else
+	SX126x_SPI.transferBytes(NULL, buffer, size);
+#endif
+	SET_SX126x_CS_HIGH();
 	SX126x_busy();
 }
 
@@ -560,27 +589,27 @@ static bool SX126x_sendPacket(sx126x_packet_t *packet)
 static void SX126x_sendBuffer(const uint8_t offset, const uint8_t *buffer, const uint8_t size)
 {
 	SX126x_busy();
-	hwDigitalWrite(MY_SX126x_CS_PIN, LOW);
+	SET_SX126x_CS_LOW();
 	SX126x_SPI.transfer(SX126x_WRITE_BUFFER);
 	SX126x_SPI.transfer(offset);
 	for (int i = 0; i < size; i++) {
 		SX126x_SPI.transfer(buffer[i]);
 	}
-	hwDigitalWrite(MY_SX126x_CS_PIN, HIGH);
+	SET_SX126x_CS_HIGH();
 	SX126x_busy();
 }
 
 static void SX126x_readBuffer(const uint8_t offset, uint8_t *buffer, const uint8_t size)
 {
 	SX126x_busy();
-	hwDigitalWrite(MY_SX126x_CS_PIN, LOW);
+	SET_SX126x_CS_LOW();
 	SX126x_SPI.transfer(SX126x_READ_BUFFER);
 	SX126x_SPI.transfer(offset);
 	SX126x_SPI.transfer(0x00); //discard status byte
 	for (int i = 0; i < size; i++) {
 		buffer[i] = SX126x_SPI.transfer(0x00);
 	}
-	hwDigitalWrite(MY_SX126x_CS_PIN, HIGH);
+	SET_SX126x_CS_HIGH();
 	SX126x_busy();
 }
 

--- a/hal/transport/SX126x/driver/SX126x.cpp
+++ b/hal/transport/SX126x/driver/SX126x.cpp
@@ -926,8 +926,8 @@ static uint8_t SX126x_getTxPowerPercent(void)
 static bool SX126x_setTxPowerPercent(const uint8_t newPowerPercent)
 {
 	const sx126x_powerLevel_t newPowerLevel = static_cast<sx126x_powerLevel_t>
-	    (MY_SX126x_MIN_POWER_LEVEL_DBM + (MY_SX126x_MAX_POWER_LEVEL_DBM
-	                                      - MY_SX126x_MIN_POWER_LEVEL_DBM) * (newPowerPercent / 100.0f));
+	        (MY_SX126x_MIN_POWER_LEVEL_DBM + (MY_SX126x_MAX_POWER_LEVEL_DBM
+	                - MY_SX126x_MIN_POWER_LEVEL_DBM) * (newPowerPercent / 100.0f));
 	SX126x_DEBUG(PSTR("SX126x:SPP:PCT=%u,TX LEVEL=%n\n"), newPowerPercent, newPowerLevel);
 	return SX126x_txPower(newPowerLevel);
 }

--- a/hal/transport/SX126x/driver/SX126x.cpp
+++ b/hal/transport/SX126x/driver/SX126x.cpp
@@ -660,7 +660,7 @@ static void SX126x_tx()
 		hwDigitalWrite(MY_SX126x_RF_SWITCH_PIN, MY_SX126x_RF_SWITCH_LPTX);
 #endif
 	} else {
-#ifdef MY_SX126x_RF_SWITCH_HPTX)
+#ifdef MY_SX126x_RF_SWITCH_HPTX
 		hwDigitalWrite(MY_SX126x_RF_SWITCH_PIN, MY_SX126x_RF_SWITCH_HPTX);
 #endif
 	}

--- a/hal/transport/SX126x/driver/SX126x.h
+++ b/hal/transport/SX126x/driver/SX126x.h
@@ -80,10 +80,17 @@
 #define _SX126x_h
 
 #include <stdint.h>
+#if defined(SUBGHZSPI_BASE)
+#include <SubGhz.h>
+#endif
 
 // SX126x hardware defaults
+#if defined(SUBGHZSPI_BASE)
+#define SX126x_SPI SubGhz.SPI //!< STM32WL SPI
+#else
 #if !defined(SX126x_SPI)
 #define SX126x_SPI hwSPI //!< default SPI
+#endif
 #endif
 
 // default PIN assignments, can be overridden
@@ -102,7 +109,7 @@
 #define DEFAULT_SX126x_IRQ_PIN			(2)				//!< DEFAULT_SX126x_IRQ_PIN
 #elif defined(LINUX_ARCH_RASPBERRYPI)
 #define DEFAULT_SX126x_IRQ_PIN			(22)			//!< DEFAULT_SX126x_IRQ_PIN
-#elif defined(ARDUINO_ARCH_STM32)
+#elif defined(ARDUINO_ARCH_STM32) && !defined(SUBGHZSPI_BASE)
 #define DEFAULT_SX126x_IRQ_PIN			(PA3)			//!< DEFAULT_SX126x_IRQ_PIN
 #elif defined(TEENSYDUINO)
 #define DEFAULT_SX126x_IRQ_PIN			(8)				//!< DEFAULT_SX126x_IRQ_PIN
@@ -110,8 +117,17 @@
 #define DEFAULT_SX126x_IRQ_PIN			(2)				//!< DEFAULT_SX126x_IRQ_PIN
 #endif
 
-#ifndef DEFAULT_SX126x_CS_PIN
+#if !defined(DEFAULT_SX126x_CS_PIN) && !defined(SUBGHZSPI_BASE)
 #define DEFAULT_SX126x_CS_PIN			(SS)			//!< DEFAULT_SX126x_CS_PIN
+#endif
+
+// cs Pin Handling
+#if defined(SUBGHZSPI_BASE)
+#define SET_SX126x_CS_LOW()   SubGhz.setNssActive(true)
+#define SET_SX126x_CS_HIGH()  SubGhz.setNssActive(false)
+#else
+#define SET_SX126x_CS_LOW()   hwDigitalWrite(MY_SX126x_CS_PIN, LOW)
+#define SET_SX126x_CS_HIGH()  hwDigitalWrite(MY_SX126x_CS_PIN, HIGH)
 #endif
 
 // Frequency helpers

--- a/hal/transport/SX126x/driver/SX126x.h
+++ b/hal/transport/SX126x/driver/SX126x.h
@@ -144,7 +144,6 @@
 #define SX126x_BROADCAST_ADDRESS (255u)	 //!< Broadcasting address
 #define SX126x_ATC_TARGET_RANGE_DBM (2u) //!< ATC target range +/- dBm
 #define SX126x_RSSI_OFFSET (137u)		 //!< RSSI offset
-#define SX126x_TARGET_RSSI (-70)		 //!< RSSI target
 #define SX126x_PROMISCUOUS (false)		 //!< SX126x promiscuous mode
 
 #if (MY_SX126x_MAX_POWER_LEVEL_DBM) <= (MY_SX126x_MIN_POWER_LEVEL_DBM)
@@ -692,7 +691,7 @@ static void SX126x_handle();
 
 /**
  * @brief Sets TX power of the module
- * @param power the output power in dDm, -3..15 for sx1261, -3..22 for sx1262
+ * @param power the output power in dDm, -17..15 for sx1261, -9..22 for sx1262
  */
 static bool SX126x_txPower(sx126x_powerLevel_t power);
 

--- a/hal/transport/SX126x/driver/SX126x.h
+++ b/hal/transport/SX126x/driver/SX126x.h
@@ -435,7 +435,7 @@ typedef struct {
 			uint8_t paDutyCycle;		//!< paDutyCycle
 			uint8_t hpMax;				//!< hpMax
 			uint8_t deviceSel;			//!< deviceSel
-			uint8_t paLut = 0x01;		//!< paLut
+			uint8_t paLut;				//!< paLut
 		} fields;						//!< fields
 		uint8_t values[4];				//!< values
 	};
@@ -594,23 +594,23 @@ typedef enum {
  * @brief PA Capabilities
  */
 #if (MY_SX126x_VARIANT == 1)
-const bool hasLPA = true;  // LP only
-const bool hasHPA = false;
+static const bool hasLPA = true;  // LP only
+static const bool hasHPA = false;
 #endif // VARIANT == 1
 #if (MY_SX126x_VARIANT == 2)
-const bool hasLPA = false;
-const bool hasHPA = true; // HP only
+static const bool hasLPA = false;
+static const bool hasHPA = true; // HP only
 #endif // VARIANT == 2
 #if (MY_SX126x_VARIANT == 3)
 #if defined(MY_SX126x_RF_SWITCH_LPTX)
-const bool hasLPA = true;
+static const bool hasLPA = true;
 #else
-const bool hasLPA = false;
+static const bool hasLPA = false;
 #endif // LPTX defined
 #if defined(MY_SX126x_RF_SWITCH_HPTX)
-const bool hasHPA = true; // HP only
+static const bool hasHPA = true; // HP only
 #else
-const bool hasHPA = false;
+static const bool hasHPA = false;
 #endif // HPTX defined
 #endif // Variant == 3
 
@@ -652,6 +652,16 @@ static void SX126x_sendRegisters(uint16_t address, uint8_t *buffer, uint16_t siz
  * @param value value to write
  */
 static void SX126x_sendRegister(uint16_t address, uint8_t value);
+
+/**
+ * @brief Provide power to the SX126x
+ **/
+void SX126x_powerUp();
+
+/**
+ * @brief Power down the SX126x
+ **/
+void SX126x_powerDown();
 
 /**
 * @brief Initialise the driver transport hardware and software

--- a/hal/transport/SX126x/driver/SX126x.h
+++ b/hal/transport/SX126x/driver/SX126x.h
@@ -592,6 +592,30 @@ typedef enum {
 } sx126x_irqMasks_t;
 
 /**
+ * @brief PA Capabilities
+ */
+#if (MY_SX126x_VARIANT == 1)
+const bool hasLPA = true;  // LP only
+const bool hasHPA = false;
+#endif // VARIANT == 1
+#if (MY_SX126x_VARIANT == 2)
+const bool hasLPA = false;
+const bool hasHPA = true; // HP only
+#endif // VARIANT == 2
+#if (MY_SX126x_VARIANT == 3)
+#if defined(MY_SX126x_RF_SWITCH_LPTX)
+const bool hasLPA = true;
+#else
+const bool hasLPA = false;
+#endif // LPTX defined
+#if defined(MY_SX126x_RF_SWITCH_HPTX)
+const bool hasHPA = true; // HP only
+#else
+const bool hasHPA = false;
+#endif // HPTX defined
+#endif // Variant == 3
+
+/**
  * @brief Sends a command to the SX126x
  * @param command SX126x command
  * @param buffer parameters


### PR DESCRIPTION
This PR changes the MySensors SX126x radio driver to allow use by STM32WL processors.

The STM32 series processors combine an STM32 processor and SX126x radio on the same chip.  The MySensors SX126x driver needs to be updated to work with the on-chip radio in the STM32WL processors.  The PR addresses 3 main differences between the SX126x radios and the internal radios in the STM32WL processors.

- For transmitting, the SX1261 radio has only a low power amplifier and the SX1262 radio has only a high power amplifier. Depending on the processor, STM32WL chips can support either low power, high power, or both amplifiers.  The PR adds code to handle Power Amplifier selection based on chip capability and desired power setting.

- Since the STM32WL processors combine the processor and radio on chip, they do not expose the normal SPI pins used by Arduino SPI libraries.  The PR adds code to use the STM32 HAL SUBGHZSPI functions to handle low level SPI calls when the STM32WL is used.

- STM32WL modules require extra pins for control of the RF front end.  This PR adds an option to use MY_SX126x_RF_SWITCH_PIN and MY_SX126x_RF_ENABLE_PIN in addition to the MY_SX126x_ANT_SWITCH_PIN already provided in the SX126x driver.  In the MySensors examples folder, the PR adds STM32WLConfiguration examples for the WIO-E5, WIO-E5-LE, and STM32WL55-Nucleo modules that show the correct defines needed for the pins in these modules.


Addresses issue #1620 

I tested these changes on STM32WLE5 (WIO-E5 and WIO-E5-LE modules)